### PR TITLE
Guard Runic Shielding curio scan when Curios is absent (#128)

### DIFF
--- a/src/main/java/com/leclowndu93150/thaumaturge/content/equipment/runic/RunicShielding.java
+++ b/src/main/java/com/leclowndu93150/thaumaturge/content/equipment/runic/RunicShielding.java
@@ -15,6 +15,7 @@ import net.minecraft.world.entity.ai.attributes.AttributeInstance;
 import net.minecraft.world.entity.ai.attributes.AttributeModifier;
 import net.minecraft.world.entity.ai.attributes.Attributes;
 import net.minecraft.world.item.ItemStack;
+import net.neoforged.fml.ModList;
 
 public final class RunicShielding {
     public static final Identifier MODIFIER_ID = TCIds.rl("runic_shielding");
@@ -29,8 +30,10 @@ public final class RunicShielding {
                 max += InfusionRunicAugmentRecipe.charge(player.getItemBySlot(slot));
             }
         }
-        for (ItemStack stack : ThaumaturgeCuriosCompat.equippedCurios(player)) {
-            max += InfusionRunicAugmentRecipe.charge(stack);
+        if (ModList.get().isLoaded(TCIds.CURIOS)) {
+            for (ItemStack stack : ThaumaturgeCuriosCompat.equippedCurios(player)) {
+                max += InfusionRunicAugmentRecipe.charge(stack);
+            }
         }
         return max;
     }


### PR DESCRIPTION
`RunicShielding.worn()` called `ThaumaturgeCuriosCompat.equippedCurios()` unconditionally from the player tick. Merely resolving that call forces `ThaumaturgeCuriosCompat` to link, and since that class hard-references Curios types (ICurio in method signatures and anonymous classes), bytecode verification throws NoClassDefFoundError without Curios installed, crashing the server one tick after a player joins.

Guard the scan behind `ModList.get().isLoaded(TCIds.CURIOS)`, matching every other ThaumaturgeCuriosCompat call site. With the call site guarded, the compat class is never linked, so no split of the compat class is needed.

Fixes #128