### PR TITLE
Open seal config GUI from Golem Bell before block interaction (#129)

### DIFF
--- a/src/main/java/com/leclowndu93150/thaumaturge/content/golem/ItemGolemBell.java
+++ b/src/main/java/com/leclowndu93150/thaumaturge/content/golem/ItemGolemBell.java
@@ -14,6 +14,7 @@ import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.context.UseOnContext;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.phys.Vec3;
@@ -51,28 +52,28 @@ public final class ItemGolemBell extends Item implements ISealDisplayer {
     }
 
     @Override
-    public InteractionResult useOn(UseOnContext context) {
+    public InteractionResult onItemUseFirst(ItemStack stack, UseOnContext context) {
         Player player = context.getPlayer();
         if (player == null) {
             return InteractionResult.PASS;
         }
-        player.swing(context.getHand(), true);
         Level level = context.getLevel();
+        ISealEntity seal =
+                SealHandler.getSealEntity(level, new SealPos(context.getClickedPos(), context.getClickedFace()));
+        if (seal == null) {
+            return InteractionResult.PASS;
+        }
+        player.swing(context.getHand(), true);
         if (level.isClientSide()) {
             return InteractionResult.SUCCESS;
         }
-        ISealEntity seal =
-                SealHandler.getSealEntity(level, new SealPos(context.getClickedPos(), context.getClickedFace()));
-        if (seal != null) {
-            if (player.isShiftKeyDown()) {
-                SealHandler.removeSealEntity((ServerLevel) level, seal.getSealPos(), false);
-                level.playSound(null, context.getClickedPos(), TCSounds.ZAP.get(), SoundSource.BLOCKS, 0.5F, 1.0F);
-            } else {
-                SealGuiOpener.open(player, seal);
-            }
-            return InteractionResult.SUCCESS_SERVER;
+        if (player.isShiftKeyDown()) {
+            SealHandler.removeSealEntity((ServerLevel) level, seal.getSealPos(), false);
+            level.playSound(null, context.getClickedPos(), TCSounds.ZAP.get(), SoundSource.BLOCKS, 0.5F, 1.0F);
+        } else {
+            SealGuiOpener.open(player, seal);
         }
-        return InteractionResult.PASS;
+        return InteractionResult.SUCCESS_SERVER;
     }
 
     public static @Nullable ISealEntity getAimedSeal(Player player) {


### PR DESCRIPTION
`ItemGolemBell` only overrode `useOn`, which vanilla calls after the block's own right-click handling. On any block with its own use behaviour (chest, barrel, furnace...) the block consumed the click first, so the seal config GUI was unreachable: not sneaking opened the block's menu, and sneaking took the shift branch and deleted the seal instead.

Move the seal lookup to `onItemUseFirst`, mirroring `ItemSealPlacer`, so it runs before the block interaction. A clicked face with a seal opens the GUI (or removes the seal when sneaking); a face without one returns PASS and the block behaves as normal. The swing/sound feedback now only plays when a seal was actually hit, since `onItemUseFirst` fires for every block click.

Fixes #129