### PR TITLE
Fix Provider seal removing itself on tick (#130)

### DIFF
--- a/src/main/java/com/leclowndu93150/thaumaturge/content/golem/seals/SealProvide.java
+++ b/src/main/java/com/leclowndu93150/thaumaturge/content/golem/seals/SealProvide.java
@@ -12,7 +12,6 @@ import com.leclowndu93150.thaumaturge.api.items.InvHelper;
 import com.leclowndu93150.thaumaturge.content.golem.EntityThaumaturgeGolem;
 import com.leclowndu93150.thaumaturge.content.golem.tasks.TaskHandler;
 import com.leclowndu93150.thaumaturge.registry.TCGolemTraits;
-import java.util.Iterator;
 import java.util.List;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
@@ -58,17 +57,11 @@ public class SealProvide extends SealFiltered implements ISealConfigToggles {
     public void tickSeal(Level level, ISealEntity seal) {
         List<ProvisionRequest> requests = GolemHelper.getProvisionRequests(level);
         if (delay % CLEAN_INTERVAL == 0) {
-            Iterator<ProvisionRequest> iterator = requests.iterator();
-            while (iterator.hasNext()) {
-                ProvisionRequest request = iterator.next();
-                if (request.isInvalid()
-                        || request.getLinkedTask() == null
-                        || request.getLinkedTask().isSuspended()
-                        || request.getLinkedTask().isCompleted()
-                        || request.getTimeout() < level.getGameTime()) {
-                    iterator.remove();
-                }
-            }
+            requests.removeIf(request -> request.isInvalid()
+                    || request.getLinkedTask() == null
+                    || request.getLinkedTask().isSuspended()
+                    || request.getLinkedTask().isCompleted()
+                    || request.getTimeout() < level.getGameTime());
         }
         if (delay++ % SCAN_INTERVAL != 0) {
             return;
@@ -78,14 +71,9 @@ public class SealProvide extends SealFiltered implements ISealConfigToggles {
         if (inv == null) {
             return;
         }
-        Iterator<ProvisionRequest> iterator = requests.iterator();
-        while (iterator.hasNext()) {
-            ProvisionRequest request = iterator.next();
-            if (request.isInvalid()) {
-                iterator.remove();
-                continue;
-            }
-            if (request.getLinkedTask() != null || !isInRange(seal, request)) {
+        requests.removeIf(ProvisionRequest::isInvalid);
+        for (ProvisionRequest request : requests) {
+            if (request.isInvalid() || request.getLinkedTask() != null || !isInRange(seal, request)) {
                 continue;
             }
             boolean filterMatch = !InvHelper.findFirstMatchFromFilter(


### PR DESCRIPTION
`SealProvide.tickSeal` called `iterator.remove()` on the `CopyOnWriteArrayList` returned by `GolemHelper.getProvisionRequests`. COW iterators throw `UnsupportedOperationException` unconditionally, and `SealHandler` responds to any tick failure by destroying the seal, so the Provider seal silently removed itself within ~5 seconds of any provision request existing.

Replace both manual iterations with `removeIf`, which is safe on a `CopyOnWriteArrayList`.

Fixes #130