### PR TITLE
Fix Goggles of Revealing floating above players head

### DIFF
--- a/src/main/java/com/leclowndu93150/thaumaturge/content/equipment/TCMaterials.java
+++ b/src/main/java/com/leclowndu93150/thaumaturge/content/equipment/TCMaterials.java
@@ -75,6 +75,15 @@ public final class TCMaterials {
             0.0F,
             () -> Ingredient.of(TCItemTags.INGOTS_THAUMIUM),
             false);
+    public static final Holder<ArmorMaterial> ARMOR_GOGGLES = register(
+            "goggles_revealing",
+            defense(0, 0, 0, 0),
+            25,
+            SoundEvents.ARMOR_EQUIP_LEATHER,
+            0.0F,
+            0.0F,
+            () -> Ingredient.EMPTY,
+            false);
     public static final Holder<ArmorMaterial> ARMOR_ROBES = register(
             "robes",
             defense(1, 2, 3, 1),

--- a/src/main/java/com/leclowndu93150/thaumaturge/content/item/equipment/GogglesItem.java
+++ b/src/main/java/com/leclowndu93150/thaumaturge/content/item/equipment/GogglesItem.java
@@ -3,6 +3,7 @@ package com.leclowndu93150.thaumaturge.content.item.equipment;
 import com.leclowndu93150.thaumaturge.api.items.IGoggles;
 import com.leclowndu93150.thaumaturge.api.items.IRevealer;
 import com.leclowndu93150.thaumaturge.api.items.IVisDiscountGear;
+import com.leclowndu93150.thaumaturge.content.equipment.TCMaterials;
 import com.leclowndu93150.thaumaturge.registry.TCItems;
 import net.minecraft.core.Holder;
 import net.minecraft.sounds.SoundEvent;
@@ -12,14 +13,13 @@ import net.minecraft.world.InteractionResultHolder;
 import net.minecraft.world.entity.EquipmentSlot;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.player.Player;
-import net.minecraft.world.item.Equipable;
-import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ArmorItem;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 
-public final class GogglesItem extends Item implements IGoggles, IRevealer, IVisDiscountGear, Equipable {
+public final class GogglesItem extends ArmorItem implements IGoggles, IRevealer, IVisDiscountGear {
     public GogglesItem(Properties properties) {
-        super(properties);
+        super(TCMaterials.ARMOR_GOGGLES, Type.HELMET, properties);
     }
 
     @Override


### PR DESCRIPTION
GogglesItem was implemented as a regular Item. It was changed to extend ArmorItem instead.

Should fix #93.

<img width="280" height="411" alt="image" src="https://github.com/user-attachments/assets/81324d0d-ddb7-46c0-b9a8-3ad4cb664a82" />
