### PR TITLE
Fix Cultist/Praetor textures and rendering

### DIFF
--- a/src/main/java/com/leclowndu93150/thaumaturge/client/entity/CultistClericRenderer.java
+++ b/src/main/java/com/leclowndu93150/thaumaturge/client/entity/CultistClericRenderer.java
@@ -31,7 +31,7 @@ public final class CultistClericRenderer
     private static final float LINE_FADE_IN_TICKS = 10.0F;
 
     public CultistClericRenderer(EntityRendererProvider.Context context) {
-        super(context, new HumanoidModel<>(context.bakeLayer(ModelLayers.PLAYER)), SHADOW);
+        super(context, new HumanoidModel<>(context.bakeLayer(TCModelLayers.CULTIST)), SHADOW);
         this.addLayer(new HumanoidArmorLayer<>(
                 this,
                 new HumanoidModel<>(context.bakeLayer(ModelLayers.PLAYER_INNER_ARMOR)),

--- a/src/main/java/com/leclowndu93150/thaumaturge/client/entity/CultistLeaderRenderer.java
+++ b/src/main/java/com/leclowndu93150/thaumaturge/client/entity/CultistLeaderRenderer.java
@@ -15,7 +15,7 @@ public final class CultistLeaderRenderer
     private static final float SHADOW = 0.5F;
 
     public CultistLeaderRenderer(EntityRendererProvider.Context context) {
-        super(context, new HumanoidModel<>(context.bakeLayer(ModelLayers.PLAYER)), SHADOW);
+        super(context, new HumanoidModel<>(context.bakeLayer(TCModelLayers.CULTIST)), SHADOW);
         this.addLayer(new HumanoidArmorLayer<>(
                 this,
                 new HumanoidModel<>(context.bakeLayer(ModelLayers.PLAYER_INNER_ARMOR)),

--- a/src/main/java/com/leclowndu93150/thaumaturge/client/entity/CultistRenderer.java
+++ b/src/main/java/com/leclowndu93150/thaumaturge/client/entity/CultistRenderer.java
@@ -14,7 +14,7 @@ public final class CultistRenderer extends HumanoidMobRenderer<EntityCultist, Hu
     private static final float SHADOW = 0.5F;
 
     public CultistRenderer(EntityRendererProvider.Context context) {
-        super(context, new HumanoidModel<>(context.bakeLayer(ModelLayers.PLAYER)), SHADOW);
+        super(context, new HumanoidModel<>(context.bakeLayer(TCModelLayers.CULTIST)), SHADOW);
         this.addLayer(new HumanoidArmorLayer<>(
                 this,
                 new HumanoidModel<>(context.bakeLayer(ModelLayers.PLAYER_INNER_ARMOR)),

--- a/src/main/java/com/leclowndu93150/thaumaturge/client/entity/TCEntityRenderers.java
+++ b/src/main/java/com/leclowndu93150/thaumaturge/client/entity/TCEntityRenderers.java
@@ -25,6 +25,9 @@ import com.leclowndu93150.thaumaturge.client.model.gear.FortressArmorModel;
 import com.leclowndu93150.thaumaturge.client.model.gear.KnightArmorModel;
 import com.leclowndu93150.thaumaturge.client.model.gear.RobeArmorModel;
 import com.leclowndu93150.thaumaturge.registry.TCEntities;
+import net.minecraft.client.model.HumanoidModel;
+import net.minecraft.client.model.geom.builders.CubeDeformation;
+import net.minecraft.client.model.geom.builders.LayerDefinition;
 import net.minecraft.client.renderer.entity.ItemEntityRenderer;
 import net.neoforged.api.distmarker.Dist;
 import net.neoforged.bus.api.SubscribeEvent;
@@ -44,6 +47,9 @@ public final class TCEntityRenderers {
 
     @SubscribeEvent
     public static void onRegisterLayers(EntityRenderersEvent.RegisterLayerDefinitions event) {
+        event.registerLayerDefinition(
+                TCModelLayers.CULTIST,
+                () -> LayerDefinition.create(HumanoidModel.createMesh(CubeDeformation.NONE, 0.0F), 64, 32));
         event.registerLayerDefinition(
                 TCModelLayers.TAINTACLE, () -> TaintacleModel.createLayer(TaintacleModel.TAINTACLE_LENGTH));
         event.registerLayerDefinition(

--- a/src/main/java/com/leclowndu93150/thaumaturge/client/entity/TCModelLayers.java
+++ b/src/main/java/com/leclowndu93150/thaumaturge/client/entity/TCModelLayers.java
@@ -4,6 +4,7 @@ import com.leclowndu93150.thaumaturge.TCIds;
 import net.minecraft.client.model.geom.ModelLayerLocation;
 
 public final class TCModelLayers {
+    public static final ModelLayerLocation CULTIST = new ModelLayerLocation(TCIds.rl("cultist"), "main");
     public static final ModelLayerLocation TAINTACLE = new ModelLayerLocation(TCIds.rl("taintacle"), "main");
     public static final ModelLayerLocation TAINTACLE_SMALL =
             new ModelLayerLocation(TCIds.rl("taintacle_small"), "main");

--- a/src/main/java/com/leclowndu93150/thaumaturge/client/extensions/CultistArmorClientExtensions.java
+++ b/src/main/java/com/leclowndu93150/thaumaturge/client/extensions/CultistArmorClientExtensions.java
@@ -33,6 +33,15 @@ public final class CultistArmorClientExtensions {
                         TCModelLayers.KNIGHT_ARMOR_HEAD,
                         TCModelLayers.KNIGHT_ARMOR_CHEST,
                         TCModelLayers.KNIGHT_ARMOR_LEGS),
+                TCItems.CRIMSON_PRAETOR_HELM.get(),
+                TCItems.CRIMSON_PRAETOR_CHEST.get(),
+                TCItems.CRIMSON_PRAETOR_LEGS.get());
+        event.registerItem(
+                new CustomArmorExtension(
+                        KnightArmorModel::new,
+                        TCModelLayers.KNIGHT_ARMOR_HEAD,
+                        TCModelLayers.KNIGHT_ARMOR_CHEST,
+                        TCModelLayers.KNIGHT_ARMOR_LEGS),
                 TCItems.CRIMSON_PLATE_HELM.get(),
                 TCItems.CRIMSON_PLATE_CHEST.get(),
                 TCItems.CRIMSON_PLATE_LEGS.get());


### PR DESCRIPTION
Cultist armor, including the Praetor armor, was using HumanoidArmorLayer, which expects a 64x32 texture, while the armor textures are 256x128. The cultist skin was using the vanilla Player model, which expects a 64x64 texture, but cultist.png is 64x32.

Armor now uses KnightArmorModel, Cultist entities use a dedicated Cultist body model with a registered 64x32 texture layer. These custom model changes may become unnecessary if the textures are updated to follow vanilla sizes.

Should fix #94

<img width="410" height="555" alt="image" src="https://github.com/user-attachments/assets/0db1232e-3fa5-465b-9ae9-76493fd3883f" />
<img width="527" height="592" alt="image" src="https://github.com/user-attachments/assets/b124a928-bab2-4d88-9a7f-d0bde12ba9ca" />
