### PR TITLE
Fix cutouts for leafs and saplings

### DIFF
--- a/src/main/java/com/leclowndu93150/thaumaturge/data/model/TCModelProvider.java
+++ b/src/main/java/com/leclowndu93150/thaumaturge/data/model/TCModelProvider.java
@@ -402,7 +402,11 @@ public final class TCModelProvider implements DataProvider {
                     pod,
                     "_stage" + i,
                     TextureMapping.cross(TextureMapping.getBlockTexture(pod, "_stem_" + i)),
-                    modelOutput);
+                    (id, json) -> modelOutput.accept(id, () -> {
+                        JsonElement element = json.get();
+                        element.getAsJsonObject().addProperty("render_type", "minecraft:cutout");
+                        return element;
+                    }));
         }
         PropertyDispatch ages = PropertyDispatch.property(BlockManaPod.AGE)
                 .select(0, v(stems[0]))
@@ -1315,7 +1319,14 @@ public final class TCModelProvider implements DataProvider {
     }
 
     private void cross(Block block) {
-        ResourceLocation model = ModelTemplates.CROSS.create(block, TextureMapping.cross(block), modelOutput);
+        ResourceLocation model = ModelTemplates.CROSS.create(
+                block,
+                TextureMapping.cross(block),
+                (id, json) -> modelOutput.accept(id, () -> {
+                    JsonElement element = json.get();
+                    element.getAsJsonObject().addProperty("render_type", "minecraft:cutout");
+                    return element;
+                }));
         simpleBlock(block, model);
     }
 

--- a/src/main/resources/assets/thaumaturge/models/block/leaves_greatwood.json
+++ b/src/main/resources/assets/thaumaturge/models/block/leaves_greatwood.json
@@ -1,5 +1,6 @@
 {
     "parent": "minecraft:block/leaves",
+    "render_type": "minecraft:cutout_mipped",
     "textures": {
         "all": "thaumaturge:block/leaves_greatwood"
     }

--- a/src/main/resources/assets/thaumaturge/models/block/leaves_silverwood.json
+++ b/src/main/resources/assets/thaumaturge/models/block/leaves_silverwood.json
@@ -1,5 +1,6 @@
 {
     "parent": "minecraft:block/leaves",
+    "render_type": "minecraft:cutout_mipped",
     "textures": {
         "all": "thaumaturge:block/leaves_silverwood"
     }

--- a/src/main/resources/assets/thaumaturge/models/block/sapling_greatwood.json
+++ b/src/main/resources/assets/thaumaturge/models/block/sapling_greatwood.json
@@ -1,5 +1,6 @@
 {
     "parent": "minecraft:block/cross",
+    "render_type": "minecraft:cutout",
     "textures": {
         "cross": "thaumaturge:block/sapling_greatwood"
     }

--- a/src/main/resources/assets/thaumaturge/models/block/sapling_silverwood.json
+++ b/src/main/resources/assets/thaumaturge/models/block/sapling_silverwood.json
@@ -1,5 +1,6 @@
 {
     "parent": "minecraft:block/cross",
+    "render_type": "minecraft:cutout",
     "textures": {
         "cross": "thaumaturge:block/sapling_silverwood"
     }


### PR DESCRIPTION
Saplings and leafs were missing some render metadata, causing Minecraft to fall back to solid rendering.
Added minecraft:cutout and minecraft:cutout_mipped to preserve transparency.

Should fix #123 

<img width="856" height="422" alt="image" src="https://github.com/user-attachments/assets/9eab18ec-de76-4308-8536-c0da981d5ab7" />
