### PR TITLE
Fix Thaumometer Interaction

### DIFF
--- a/src/main/java/com/leclowndu93150/thaumaturge/content/item/ThaumometerEntityInteractionEvents.java
+++ b/src/main/java/com/leclowndu93150/thaumaturge/content/item/ThaumometerEntityInteractionEvents.java
@@ -5,7 +5,6 @@ import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.player.Player;
-import net.minecraft.world.item.ItemStack;
 import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.common.EventBusSubscriber;
 import net.neoforged.neoforge.event.entity.player.PlayerInteractEvent;
@@ -33,8 +32,8 @@ public final class ThaumometerEntityInteractionEvents {
     }
 
     private static boolean intercept(Player player, InteractionHand hand, Entity target) {
-        boolean isInteracting = !player.isShiftKeyDown()
-                && player.getItemInHand(hand).getItem() instanceof ThaumometerItem;
+        boolean isInteracting =
+                !player.isShiftKeyDown() && player.getItemInHand(hand).getItem() instanceof ThaumometerItem;
 
         if (!isInteracting) {
             return false;

--- a/src/main/java/com/leclowndu93150/thaumaturge/content/item/ThaumometerEntityInteractionEvents.java
+++ b/src/main/java/com/leclowndu93150/thaumaturge/content/item/ThaumometerEntityInteractionEvents.java
@@ -1,0 +1,49 @@
+package com.leclowndu93150.thaumaturge.content.item;
+
+import com.leclowndu93150.thaumaturge.TCIds;
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.InteractionResult;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.ItemStack;
+import net.neoforged.bus.api.SubscribeEvent;
+import net.neoforged.fml.common.EventBusSubscriber;
+import net.neoforged.neoforge.event.entity.player.PlayerInteractEvent;
+
+@EventBusSubscriber(modid = TCIds.MODID)
+public final class ThaumometerEntityInteractionEvents {
+    private ThaumometerEntityInteractionEvents() {}
+
+    @SubscribeEvent
+    public static void onEntityInteractSpecific(PlayerInteractEvent.EntityInteractSpecific event) {
+        InteractionResult result = tryBeginScan(event.getEntity(), event.getHand(), event.getTarget());
+        if (result == InteractionResult.PASS) {
+            return;
+        }
+        event.setCancellationResult(result);
+        event.setCanceled(true);
+    }
+
+    @SubscribeEvent
+    public static void onEntityInteract(PlayerInteractEvent.EntityInteract event) {
+        InteractionResult result = tryBeginScan(event.getEntity(), event.getHand(), event.getTarget());
+        if (result == InteractionResult.PASS) {
+            return;
+        }
+        event.setCancellationResult(result);
+        event.setCanceled(true);
+    }
+
+    private static InteractionResult tryBeginScan(Player player, InteractionHand hand, Entity target) {
+        if (player.isShiftKeyDown()) {
+            return InteractionResult.PASS;
+        }
+
+        ItemStack stack = player.getItemInHand(hand);
+        if (!(stack.getItem() instanceof ThaumometerItem)) {
+            return InteractionResult.PASS;
+        }
+
+        return ThaumometerItem.beginScanAt(player, hand, target);
+    }
+}

--- a/src/main/java/com/leclowndu93150/thaumaturge/content/item/ThaumometerEntityInteractionEvents.java
+++ b/src/main/java/com/leclowndu93150/thaumaturge/content/item/ThaumometerEntityInteractionEvents.java
@@ -16,34 +16,33 @@ public final class ThaumometerEntityInteractionEvents {
 
     @SubscribeEvent
     public static void onEntityInteractSpecific(PlayerInteractEvent.EntityInteractSpecific event) {
-        InteractionResult result = tryBeginScan(event.getEntity(), event.getHand(), event.getTarget());
-        if (result == InteractionResult.PASS) {
+        if (!intercept(event.getEntity(), event.getHand(), event.getTarget())) {
             return;
         }
-        event.setCancellationResult(result);
+        event.setCancellationResult(InteractionResult.CONSUME);
         event.setCanceled(true);
     }
 
     @SubscribeEvent
     public static void onEntityInteract(PlayerInteractEvent.EntityInteract event) {
-        InteractionResult result = tryBeginScan(event.getEntity(), event.getHand(), event.getTarget());
-        if (result == InteractionResult.PASS) {
+        if (!intercept(event.getEntity(), event.getHand(), event.getTarget())) {
             return;
         }
-        event.setCancellationResult(result);
+        event.setCancellationResult(InteractionResult.CONSUME);
         event.setCanceled(true);
     }
 
-    private static InteractionResult tryBeginScan(Player player, InteractionHand hand, Entity target) {
-        if (player.isShiftKeyDown()) {
-            return InteractionResult.PASS;
+    private static boolean intercept(Player player, InteractionHand hand, Entity target) {
+        boolean isInteracting = !player.isShiftKeyDown()
+                && player.getItemInHand(hand).getItem() instanceof ThaumometerItem;
+
+        if (!isInteracting) {
+            return false;
         }
 
-        ItemStack stack = player.getItemInHand(hand);
-        if (!(stack.getItem() instanceof ThaumometerItem)) {
-            return InteractionResult.PASS;
+        if (!player.level().isClientSide()) {
+            ThaumometerItem.beginScanAt(player, hand, target);
         }
-
-        return ThaumometerItem.beginScanAt(player, hand, target);
+        return true;
     }
 }

--- a/src/main/java/com/leclowndu93150/thaumaturge/content/item/ThaumometerItem.java
+++ b/src/main/java/com/leclowndu93150/thaumaturge/content/item/ThaumometerItem.java
@@ -58,7 +58,11 @@ public final class ThaumometerItem extends Item {
     }
 
     private InteractionResult beginScan(Level level, Player player, InteractionHand hand) {
-        if (!ScanningManager.isThingStillScannable(player, resolveTarget(level, player))) {
+        return beginScanAt(player, hand, resolveTarget(level, player));
+    }
+
+    static InteractionResult beginScanAt(Player player, InteractionHand hand, @Nullable Object target) {
+        if (!ScanningManager.isThingStillScannable(player, target)) {
             return InteractionResult.PASS;
         }
         player.startUsingItem(hand);


### PR DESCRIPTION
Implements entity interaction events for the Thaumometer, allowing players to use it on entities such as the Wandering Trader.

Should fix #151

<img width="917" height="514" alt="image" src="https://github.com/user-attachments/assets/738d3a31-c06a-4cb9-9645-c16ebb3e20f6" />
