### PR TITLE
Fix client registry mismatch in smeltery and efficiency loss

### DIFF
--- a/src/main/java/com/leclowndu93150/thaumaturge/client/network/AspectIndexClientHandler.java
+++ b/src/main/java/com/leclowndu93150/thaumaturge/client/network/AspectIndexClientHandler.java
@@ -2,12 +2,17 @@ package com.leclowndu93150.thaumaturge.client.network;
 
 import com.leclowndu93150.thaumaturge.content.aspect.AspectIndexHolder;
 import com.leclowndu93150.thaumaturge.network.ClientboundAspectIndexPayload;
+import net.minecraft.client.Minecraft;
 import net.neoforged.neoforge.network.handling.IPayloadContext;
 
 public final class AspectIndexClientHandler {
     private AspectIndexClientHandler() {}
 
     public static void handle(ClientboundAspectIndexPayload payload, IPayloadContext ctx) {
-        ctx.enqueueWork(() -> AspectIndexHolder.set(payload.index()));
+        ctx.enqueueWork(() -> {
+            if (!Minecraft.getInstance().hasSingleplayerServer()) {
+                AspectIndexHolder.set(payload.index());
+            }
+        });
     }
 }

--- a/src/main/java/com/leclowndu93150/thaumaturge/content/essentia/smeltery/BlockEntitySmelter.java
+++ b/src/main/java/com/leclowndu93150/thaumaturge/content/essentia/smeltery/BlockEntitySmelter.java
@@ -249,8 +249,9 @@ public class BlockEntitySmelter extends BlockEntity implements MenuProvider {
                     }
                 }
             }
-            this.aspects = this.aspects.add(instance);
         }
+
+        this.aspects = this.aspects.add(aspects);
 
         if (flux > 0) {
             int pp = 0;
@@ -306,7 +307,7 @@ public class BlockEntitySmelter extends BlockEntity implements MenuProvider {
 
             AuraHelper.polluteAura(level, getBlockPos(), pp, true);
         }
-        this.vis = aspects.totalAmount();
+        this.vis = this.aspects.totalAmount();
         inventory.extractItem(0, 1, false);
     }
 

--- a/src/main/java/com/leclowndu93150/thaumaturge/content/essentia/smeltery/BlockEntitySmelter.java
+++ b/src/main/java/com/leclowndu93150/thaumaturge/content/essentia/smeltery/BlockEntitySmelter.java
@@ -125,16 +125,20 @@ public class BlockEntitySmelter extends BlockEntity implements MenuProvider {
     @Override
     public void setRemoved() {
         super.setRemoved();
+    }
+
+    void dropContents() {
         if (level == null || level.isClientSide()) return;
         NonNullList<ItemStack> drops = NonNullList.withSize(getInventory().getSlots(), ItemStack.EMPTY);
         for (int slot = 0; slot < getInventory().getSlots(); slot++) {
-            drops.set(slot, getInventory().getStackInSlot(slot));
+            drops.set(slot, getInventory().getStackInSlot(slot).copy());
+            getInventory().setStackInSlot(slot, ItemStack.EMPTY);
         }
         Containers.dropContents(level, getBlockPos(), drops);
         if (aspects.totalAmount() > 0) {
             AuraHelper.polluteAura(level, getBlockPos(), aspects.totalAmount(), true);
-            setChanged();
-            syncToClient();
+            aspects = AspectList.EMPTY;
+            vis = 0;
         }
     }
 

--- a/src/main/java/com/leclowndu93150/thaumaturge/content/essentia/smeltery/BlockSmelter.java
+++ b/src/main/java/com/leclowndu93150/thaumaturge/content/essentia/smeltery/BlockSmelter.java
@@ -68,6 +68,9 @@ public class BlockSmelter extends BaseEntityBlock {
     public void onRemove(BlockState state, Level level, BlockPos pos, BlockState newState, boolean movedByPiston) {
         if (!state.is(newState.getBlock())) {
             level.updateNeighbourForOutputSignal(pos, state.getBlock());
+            if (level.getBlockEntity(pos) instanceof BlockEntitySmelter smelter) {
+                smelter.dropContents();
+            }
         }
         super.onRemove(state, level, pos, newState, movedByPiston);
     }


### PR DESCRIPTION
Essentia Smeltery aspect encoding was failing because the client was overwriting the server's registry in singleplayer

Also fixed an issue where aspect loss from efficiency was being calculated correctly, but the original amount was still being added to the smeltery

This requires further testing in singleplayer, LAN, and multiplayer. If the previously essentia amounts were actually the intended behavior, please feel free to revert these changes

Should fix #91 