### PR TITLE
Fix Mind Spider eye texture path and transparency

### DIFF
--- a/src/main/java/com/leclowndu93150/thaumaturge/client/entity/MindSpiderRenderer.java
+++ b/src/main/java/com/leclowndu93150/thaumaturge/client/entity/MindSpiderRenderer.java
@@ -62,7 +62,7 @@ public final class MindSpiderRenderer extends MobRenderer<EntityMindSpider, Spid
     @Override
     protected @Nullable RenderType getRenderType(
             EntityMindSpider entity, boolean isBodyVisible, boolean forceTransparent, boolean appearGlowing) {
-        return RenderType.itemEntityTranslucentCull(getTextureLocation(entity));
+        return RenderType.entityTranslucent(getTextureLocation(entity));
     }
 
     @Override
@@ -73,7 +73,7 @@ public final class MindSpiderRenderer extends MobRenderer<EntityMindSpider, Spid
     private static final class GhostSpiderEyesLayer
             extends RenderLayer<EntityMindSpider, SpiderModel<EntityMindSpider>> {
         private static final RenderType SPIDER_EYES =
-                RenderType.eyes(ResourceLocation.withDefaultNamespace("textures/entity/spider/spider_eyes.png"));
+                RenderType.eyes(ResourceLocation.withDefaultNamespace("textures/entity/spider_eyes.png"));
 
         GhostSpiderEyesLayer(RenderLayerParent<EntityMindSpider, SpiderModel<EntityMindSpider>> renderer) {
             super(renderer);


### PR DESCRIPTION
It was using the wrong path for its eyes, causing the spider to render purple
Also changed RenderType to use entityTranslucent instead

Should fix #75 

<img width="688" height="507" alt="image" src="https://github.com/user-attachments/assets/54dd0238-2cf0-4b90-976a-05485657a10c" />
