### PR TITLE
Fix hungry node block eating, item pulling and particles

### DIFF
--- a/src/main/java/com/leclowndu93150/thaumaturge/config/ThaumaturgeCommonConfig.java
+++ b/src/main/java/com/leclowndu93150/thaumaturge/config/ThaumaturgeCommonConfig.java
@@ -66,11 +66,11 @@ public final class ThaumaturgeCommonConfig {
         NETHER_NODE_CHANCE = builder.comment(
                         "Chance from 0 to 100 for a node placement attempt in each Nether chunk. 2.5 means one attempt per 40 chunks. 0 disables Nether nodes.")
                 .defineInRange("netherSpawnChance", 2.5, 0.0, 100.0);
-      
+
         builder.comment(
                         "The following values are percentages among ordinary random nodes. Their default total is 6.6667%, leaving 93.3333% normal nodes. If their total exceeds 100, they are treated as relative weights and normal nodes become 0%.")
                 .push("types");
-      
+
         DARK_NODE_CHANCE = builder.comment("Dark-node percentage, from 0 to 100. Default: 2%.")
                 .defineInRange("darkChance", 2.0, 0.0, 100.0);
         UNSTABLE_NODE_CHANCE = builder.comment("Unstable-node percentage, from 0 to 100. Default: 2%.")
@@ -80,9 +80,9 @@ public final class ThaumaturgeCommonConfig {
         HUNGRY_NODE_CHANCE = builder.comment(
                         "Hungry-node percentage, from 0 to 100. Default: 0.6667%, approximately one hungry node per 150 ordinary nodes.")
                 .defineInRange("hungryChance", 2.0 / 3.0, 0.0, 100.0);
-      
+
         builder.pop(2);
-      
+
         HUNGRY_NODE_BLOCK_EAT_RANGE = builder.comment(
                         "Maximum length in blocks of a hungry node's random block-eating ray.",
                         "Default: 16. Range: 1 to 64. A larger area gives each attempt more possible targets; it does not guarantee a distant block will be selected.",
@@ -125,24 +125,23 @@ public final class ThaumaturgeCommonConfig {
         NO_SLEEP = builder.comment(
                         "Setting this to true will make you get the recipe book for salis mundus without having to sleep first.")
                 .define("noSleep", false);
-      
+
         builder.pop();
         builder.push("sounds");
-      
+
         NO_STRESS = builder.comment(
                         "Set to true to disable anxiety triggers like the heartbeat sound and warp-event jump scares.")
                 .define("nostress", false);
-      
+
         builder.pop();
         builder.push("golems");
-      
+
         SHOW_GOLEM_EMOTES = builder.comment(
                         "Will golems display emote particles if they receive orders or encounter problems.")
                 .define("showGolemEmotes", true);
-      
+
         builder.pop();
         SPEC = builder.build();
-      
     }
 
     private ThaumaturgeCommonConfig() {}

--- a/src/main/java/com/leclowndu93150/thaumaturge/content/aura/node/BlockEntityNode.java
+++ b/src/main/java/com/leclowndu93150/thaumaturge/content/aura/node/BlockEntityNode.java
@@ -1,6 +1,7 @@
 package com.leclowndu93150.thaumaturge.content.aura.node;
 
 import com.leclowndu93150.thaumaturge.TCIds;
+import com.leclowndu93150.thaumaturge.api.aspect.AspectIndexAccess;
 import com.leclowndu93150.thaumaturge.api.aspect.AspectInstance;
 import com.leclowndu93150.thaumaturge.api.aspect.AspectList;
 import com.leclowndu93150.thaumaturge.api.aspect.IAspect;
@@ -14,6 +15,7 @@ import com.leclowndu93150.thaumaturge.config.ThaumaturgeCommonConfig;
 import com.leclowndu93150.thaumaturge.content.aspect.EntityAspects;
 import com.leclowndu93150.thaumaturge.content.effect.Effects;
 import com.leclowndu93150.thaumaturge.content.entity.EntityBrainyZombie;
+import com.leclowndu93150.thaumaturge.content.particle.BoreDebrisParticleOptions;
 import com.leclowndu93150.thaumaturge.content.wands.EntityAspectOrb;
 import com.leclowndu93150.thaumaturge.content.wands.WandChargingEvents;
 import com.leclowndu93150.thaumaturge.content.wands.WandEconomy;
@@ -31,11 +33,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
 import net.minecraft.core.Holder;
 import net.minecraft.core.HolderLookup;
 import net.minecraft.core.UUIDUtil;
-import net.minecraft.core.particles.BlockParticleOption;
-import net.minecraft.core.particles.ParticleTypes;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.protocol.Packet;
@@ -49,6 +50,7 @@ import net.minecraft.util.RandomSource;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.MobSpawnType;
+import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.ClipContext;
@@ -80,8 +82,10 @@ public class BlockEntityNode extends BlockEntity implements IAspectContainer {
     private static final float BRIGHTEN_FILL_FRACTION = 0.9F;
     private static final int BRIGHTEN_CHANCE = 50;
     private static final int HUNGRY_REACH = 16;
+    private static final double HUNGRY_RAY_START_OFFSET = 0.25;
     private static final double HUNGRY_PULL_RANGE = 15.0;
-    private static final double HUNGRY_EAT_RANGE_SQ = 2.0;
+    private static final double HUNGRY_ITEM_PULL_RANGE = HUNGRY_REACH + 0.5;
+    private static final double HUNGRY_EAT_RANGE_SQ = 4.0;
     private static final float HUNGRY_MAX_HARDNESS = 5.0F;
     private static final int DARK_SPAWN_PLAYER_RANGE = 24;
     private static final int DARK_SPAWN_CAP = 3;
@@ -804,7 +808,8 @@ public class BlockEntityNode extends BlockEntity implements IAspectContainer {
             return change;
         }
         Vec3 center = Vec3.atCenterOf(pos);
-        List<Entity> targets = serverLevel.getEntitiesOfClass(Entity.class, new AABB(pos).inflate(HUNGRY_PULL_RANGE));
+        List<Entity> targets =
+                serverLevel.getEntitiesOfClass(Entity.class, new AABB(pos).inflate(HUNGRY_ITEM_PULL_RANGE));
         for (Entity target : targets) {
             if (target instanceof Player player && (player.isCreative() || player.isSpectator())) {
                 continue;
@@ -813,14 +818,28 @@ public class BlockEntityNode extends BlockEntity implements IAspectContainer {
                 continue;
             }
             double distanceSq = target.distanceToSqr(center);
+            double pullRange = target instanceof ItemEntity ? HUNGRY_ITEM_PULL_RANGE : HUNGRY_PULL_RANGE;
+            if (distanceSq >= pullRange * pullRange) {
+                continue;
+            }
             if (distanceSq < HUNGRY_EAT_RANGE_SQ) {
-                target.hurt(serverLevel.damageSources().fellOutOfWorld(), 1.0F);
+                if (target instanceof ItemEntity item) {
+                    ItemStack stack = item.getItem();
+                    AspectList itemAspects = AspectIndexAccess.of(stack);
+                    item.hurt(serverLevel.damageSources().fellOutOfWorld(), 1.0F);
+                    if (!item.isAlive()) {
+                        devour(serverLevel, itemAspects, stack.getCount());
+                        change = true;
+                    }
+                } else {
+                    target.hurt(serverLevel.damageSources().fellOutOfWorld(), 1.0F);
+                }
                 if (!target.isAlive() && target instanceof LivingEntity living) {
                     devour(serverLevel, living);
                     change = true;
                 }
             }
-            Vec3 delta = center.subtract(target.position()).scale(1.0 / HUNGRY_PULL_RANGE);
+            Vec3 delta = center.subtract(target.position()).scale(1.0 / pullRange);
             double length = delta.length();
             double power = 1.0 - length;
             if (power > 0.0) {
@@ -828,17 +847,21 @@ public class BlockEntityNode extends BlockEntity implements IAspectContainer {
                 Vec3 pull = delta.normalize();
                 target.setDeltaMovement(target.getDeltaMovement()
                         .add(pull.x * power * 0.15, pull.y * power * 0.25, pull.z * power * 0.15));
+                target.hasImpulse = true;
             }
         }
         return change;
     }
 
     private void devour(ServerLevel serverLevel, LivingEntity living) {
-        AspectList entityAspects = EntityAspects.of(living);
-        if (entityAspects.isEmpty()) {
+        devour(serverLevel, EntityAspects.of(living), 1);
+    }
+
+    private void devour(ServerLevel serverLevel, AspectList sourceAspects, int count) {
+        if (sourceAspects.isEmpty() || count <= 0) {
             return;
         }
-        Map<ResourceKey<IAspect>, Integer> primals = WandChargingEvents.reduceToPrimals(entityAspects);
+        Map<ResourceKey<IAspect>, Integer> primals = WandChargingEvents.reduceToPrimals(sourceAspects);
         if (primals.isEmpty()) {
             return;
         }
@@ -847,10 +870,12 @@ public class BlockEntityNode extends BlockEntity implements IAspectContainer {
         ResourceKey<IAspect> chosen = keys.get(random.nextInt(keys.size()));
         Holder<IAspect> holder =
                 serverLevel.registryAccess().lookupOrThrow(IAspect.REGISTRY_KEY).getOrThrow(chosen);
+        int available = primals.get(chosen) * count;
         if (aspects.amountOf(holder) < aspectsBase.amountOf(holder)) {
             addToContainer(holder, 1);
-        } else if (random.nextInt(1 + aspectsBase.amountOf(holder) * 2) < primals.get(chosen)) {
+        } else if (random.nextInt(1 + aspectsBase.amountOf(holder) * 2) < available) {
             aspectsBase = raiseBase(aspectsBase, holder, 1);
+            aspects = aspects.add(holder, 1);
         }
         nodeChange();
     }
@@ -859,10 +884,8 @@ public class BlockEntityNode extends BlockEntity implements IAspectContainer {
         int tx = pos.getX() + random.nextInt(HUNGRY_REACH) - random.nextInt(HUNGRY_REACH);
         int ty = pos.getY() + random.nextInt(HUNGRY_REACH) - random.nextInt(HUNGRY_REACH);
         int tz = pos.getZ() + random.nextInt(HUNGRY_REACH) - random.nextInt(HUNGRY_REACH);
-        Vec3 from = Vec3.atCenterOf(pos);
         Vec3 to = new Vec3(tx + 0.5, ty + 0.5, tz + 0.5);
-        BlockHitResult hit = serverLevel.clip(
-                new ClipContext(from, to, ClipContext.Block.OUTLINE, ClipContext.Fluid.NONE, CollisionContext.empty()));
+        BlockHitResult hit = hungryNodeClip(serverLevel, pos, to);
         if (hit.getType() != HitResult.Type.BLOCK) {
             return;
         }
@@ -875,6 +898,21 @@ public class BlockEntityNode extends BlockEntity implements IAspectContainer {
         if (!state.isAir() && hardness >= 0.0F && hardness < HUNGRY_MAX_HARDNESS) {
             serverLevel.destroyBlock(target, true);
         }
+    }
+
+    /**
+     * Clips outward from just beyond the node's outline. Starting at the block center makes the
+     * node hit its own selection shape, preventing hungry nodes from ever reaching another block.
+     */
+    private static BlockHitResult hungryNodeClip(Level level, BlockPos pos, Vec3 to) {
+        Vec3 center = Vec3.atCenterOf(pos);
+        Vec3 direction = to.subtract(center);
+        if (direction.lengthSqr() < 1.0E-7) {
+            return BlockHitResult.miss(to, Direction.UP, pos);
+        }
+        Vec3 from = center.add(direction.normalize().scale(HUNGRY_RAY_START_OFFSET));
+        return level.clip(
+                new ClipContext(from, to, ClipContext.Block.OUTLINE, ClipContext.Fluid.NONE, CollisionContext.empty()));
     }
 
     public void burstIntoOrbs(ServerLevel serverLevel, BlockPos pos) {
@@ -960,8 +998,7 @@ public class BlockEntityNode extends BlockEntity implements IAspectContainer {
         int tz = pos.getZ() + random.nextInt(HUNGRY_REACH) - random.nextInt(HUNGRY_REACH);
         Vec3 from = Vec3.atCenterOf(pos);
         Vec3 to = new Vec3(tx + 0.5, ty + 0.5, tz + 0.5);
-        BlockHitResult hit = clientLevel.clip(
-                new ClipContext(from, to, ClipContext.Block.OUTLINE, ClipContext.Fluid.NONE, CollisionContext.empty()));
+        BlockHitResult hit = hungryNodeClip(clientLevel, pos, to);
         if (hit.getType() != HitResult.Type.BLOCK) {
             return;
         }
@@ -973,17 +1010,14 @@ public class BlockEntityNode extends BlockEntity implements IAspectContainer {
         if (state.isAir()) {
             return;
         }
-        Vec3 pull = from.subtract(Vec3.atCenterOf(target)).normalize().scale(0.3);
-        for (int i = 0; i < 3; i++) {
-            clientLevel.addParticle(
-                    new BlockParticleOption(ParticleTypes.BLOCK, state),
-                    target.getX() + random.nextFloat(),
-                    target.getY() + random.nextFloat(),
-                    target.getZ() + random.nextFloat(),
-                    pull.x,
-                    pull.y + 0.05,
-                    pull.z);
-        }
+        clientLevel.addParticle(
+                new BoreDebrisParticleOptions(state, from.x, from.y, from.z, 0.0, 0.0, 0.0),
+                target.getX() + random.nextFloat(),
+                target.getY() + random.nextFloat(),
+                target.getZ() + random.nextFloat(),
+                0.0,
+                0.0,
+                0.0);
     }
 
     @Override


### PR DESCRIPTION
fixes hungry nodes not working properly;

- fixes the node raycast hitting itself
- blocks are now actually destroyed
- destroyed blocks drop their items
- item drops consistently get pulled into the node
- fixes the item pull range being shorter than the block destruction range
- fixes items disappearing instantly when close to the node
- fixes the consumption radius being too small
- consumed items correctly add their aspects to the node
- block particles now move towards the node like they did in old thaumcraft

cross checked against 1.7.10