### PR TITLE
[1.21.1][Feature] Add node locate command

### DIFF
--- a/src/main/java/com/leclowndu93150/thaumaturge/content/aura/node/BlockEntityNode.java
+++ b/src/main/java/com/leclowndu93150/thaumaturge/content/aura/node/BlockEntityNode.java
@@ -22,6 +22,7 @@ import com.leclowndu93150.thaumaturge.content.wands.WandVisHelper;
 import com.leclowndu93150.thaumaturge.data.worldgen.biome.TCBiomes;
 import com.leclowndu93150.thaumaturge.registry.TCBlockEntities;
 import com.leclowndu93150.thaumaturge.registry.TCBlockTags;
+import com.leclowndu93150.thaumaturge.registry.TCBlocks;
 import com.leclowndu93150.thaumaturge.registry.TCEntities;
 import com.leclowndu93150.thaumaturge.registry.TCWandParts;
 import com.leclowndu93150.thaumaturge.serialization.TCNbt;
@@ -155,6 +156,17 @@ public class BlockEntityNode extends BlockEntity implements IAspectContainer {
 
     public void setNodeType(NodeType type) {
         this.nodeType = type;
+        if (level instanceof ServerLevel serverLevel && getBlockState().is(TCBlocks.NODE.get())) {
+            NodeLocationIndex.get(serverLevel).register(worldPosition, type);
+        }
+    }
+
+    @Override
+    public void onLoad() {
+        super.onLoad();
+        if (level instanceof ServerLevel serverLevel && getBlockState().is(TCBlocks.NODE.get())) {
+            NodeLocationIndex.get(serverLevel).register(worldPosition, nodeType);
+        }
     }
 
     public @Nullable NodeModifier getNodeModifier() {
@@ -495,7 +507,7 @@ public class BlockEntityNode extends BlockEntity implements IAspectContainer {
         } else if (nodeModifier == NodeModifier.PALE) {
             nodeModifier = NodeModifier.FADING;
         } else if (nodeModifier == NodeModifier.FADING && nodeType != NodeType.HUNGRY) {
-            nodeType = NodeType.HUNGRY;
+            setNodeType(NodeType.HUNGRY);
         }
         nodeChange();
     }
@@ -510,7 +522,7 @@ public class BlockEntityNode extends BlockEntity implements IAspectContainer {
                 && nodeType != NodeType.PURE
                 && flux > base * FLUX_TAINT_THRESHOLD
                 && random.nextInt(FLUX_TAINT_CHANCE) == 0) {
-            nodeType = NodeType.TAINTED;
+            setNodeType(NodeType.TAINTED);
             nodeChange();
             return;
         }
@@ -678,7 +690,7 @@ public class BlockEntityNode extends BlockEntity implements IAspectContainer {
                     return true;
                 }
             } else if (random.nextInt(UNSTABLE_CURE_ROLL / lock) == UNSTABLE_CURE_MAGIC) {
-                nodeType = NodeType.NORMAL;
+                setNodeType(NodeType.NORMAL);
                 nodeChange();
                 return true;
             }

--- a/src/main/java/com/leclowndu93150/thaumaturge/content/aura/node/BlockNode.java
+++ b/src/main/java/com/leclowndu93150/thaumaturge/content/aura/node/BlockNode.java
@@ -74,4 +74,12 @@ public final class BlockNode extends Block implements EntityBlock {
         }
         return super.playerWillDestroy(level, pos, state, player);
     }
+
+    @Override
+    protected void onRemove(BlockState state, Level level, BlockPos pos, BlockState newState, boolean movedByPiston) {
+        if (level instanceof ServerLevel serverLevel && !state.is(newState.getBlock())) {
+            NodeLocationIndex.get(serverLevel).remove(pos);
+        }
+        super.onRemove(state, level, pos, newState, movedByPiston);
+    }
 }

--- a/src/main/java/com/leclowndu93150/thaumaturge/content/aura/node/NodeLocationIndex.java
+++ b/src/main/java/com/leclowndu93150/thaumaturge/content/aura/node/NodeLocationIndex.java
@@ -1,0 +1,167 @@
+package com.leclowndu93150.thaumaturge.content.aura.node;
+
+import com.leclowndu93150.thaumaturge.api.nodes.NodeType;
+import java.util.Comparator;
+import java.util.EnumMap;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.HolderLookup;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.ListTag;
+import net.minecraft.nbt.StringTag;
+import net.minecraft.nbt.Tag;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.util.datafix.DataFixTypes;
+import net.minecraft.world.level.saveddata.SavedData;
+
+/** Persistent index used by the node locator command. */
+public final class NodeLocationIndex extends SavedData {
+    private static final String DATA_NAME = "thaumaturge_node_locations";
+    private static final double REACHED_DISTANCE_SQ = 10.0 * 10.0;
+    private static final SavedData.Factory<NodeLocationIndex> FACTORY =
+            new SavedData.Factory<>(NodeLocationIndex::new, NodeLocationIndex::load, DataFixTypes.LEVEL);
+
+    private final Map<NodeType, Set<Long>> nodes = new EnumMap<>(NodeType.class);
+    private final Map<UUID, Set<Long>> reachedNodes = new HashMap<>();
+    private final Map<UUID, Long> lastLocatedNodes = new HashMap<>();
+
+    public NodeLocationIndex() {
+        for (NodeType type : NodeType.values()) {
+            nodes.put(type, new HashSet<>());
+        }
+    }
+
+    public static NodeLocationIndex get(ServerLevel level) {
+        return level.getDataStorage().computeIfAbsent(FACTORY, DATA_NAME);
+    }
+
+    public void register(BlockPos pos, NodeType type) {
+        long packed = pos.asLong();
+        boolean changed = false;
+        for (Map.Entry<NodeType, Set<Long>> entry : nodes.entrySet()) {
+            if (entry.getKey() != type) {
+                changed |= entry.getValue().remove(packed);
+            }
+        }
+        changed |= nodes.get(type).add(packed);
+        if (changed) {
+            setDirty();
+        }
+    }
+
+    public void remove(BlockPos pos) {
+        long packed = pos.asLong();
+        boolean changed = false;
+        for (Set<Long> positions : nodes.values()) {
+            changed |= positions.remove(packed);
+        }
+        if (changed) {
+            lastLocatedNodes.values().removeIf(value -> value == packed);
+            reachedNodes.values().forEach(positions -> positions.remove(packed));
+            setDirty();
+        }
+    }
+
+    public Optional<BlockPos> findNearest(UUID playerId, BlockPos origin, NodeType type) {
+        markLastLocatedReached(playerId, origin);
+        Set<Long> reached = reachedNodes.getOrDefault(playerId, Set.of());
+        Optional<Long> nearest = nodes.get(type).stream()
+                .filter(pos -> !reached.contains(pos))
+                .min(Comparator.comparingDouble(pos -> BlockPos.of(pos).distSqr(origin)));
+        nearest.ifPresent(pos -> {
+            lastLocatedNodes.put(playerId, pos);
+            setDirty();
+        });
+        return nearest.map(BlockPos::of);
+    }
+
+    private void markLastLocatedReached(UUID playerId, BlockPos origin) {
+        Long last = lastLocatedNodes.get(playerId);
+        if (last == null || BlockPos.of(last).distSqr(origin) > REACHED_DISTANCE_SQ) {
+            return;
+        }
+        reachedNodes.computeIfAbsent(playerId, ignored -> new HashSet<>()).add(last);
+        lastLocatedNodes.remove(playerId);
+        setDirty();
+    }
+
+    private static NodeLocationIndex load(CompoundTag tag, HolderLookup.Provider registries) {
+        NodeLocationIndex index = new NodeLocationIndex();
+        ListTag nodeList = tag.getList("Nodes", Tag.TAG_COMPOUND);
+        for (Tag value : nodeList) {
+            CompoundTag node = (CompoundTag) value;
+            parseType(node.getString("Type"))
+                    .ifPresent(type -> index.nodes.get(type).add(node.getLong("Pos")));
+        }
+        ListTag players = tag.getList("Players", Tag.TAG_COMPOUND);
+        for (Tag value : players) {
+            CompoundTag player = (CompoundTag) value;
+            if (!player.hasUUID("Id")) {
+                continue;
+            }
+            UUID id = player.getUUID("Id");
+            Set<Long> reached = new HashSet<>();
+            for (Tag packed : player.getList("Reached", Tag.TAG_STRING)) {
+                try {
+                    reached.add(Long.parseLong(packed.getAsString()));
+                } catch (NumberFormatException ignored) {
+                    // Ignore malformed legacy/user-edited entries.
+                }
+            }
+            if (!reached.isEmpty()) {
+                index.reachedNodes.put(id, reached);
+            }
+            if (player.contains("Last", Tag.TAG_LONG)) {
+                index.lastLocatedNodes.put(id, player.getLong("Last"));
+            }
+        }
+        return index;
+    }
+
+    @Override
+    public CompoundTag save(CompoundTag tag, HolderLookup.Provider registries) {
+        ListTag nodeList = new ListTag();
+        nodes.forEach((type, positions) -> positions.forEach(pos -> {
+            CompoundTag node = new CompoundTag();
+            node.putString("Type", type.getSerializedName());
+            node.putLong("Pos", pos);
+            nodeList.add(node);
+        }));
+        tag.put("Nodes", nodeList);
+
+        ListTag players = new ListTag();
+        Set<UUID> playerIds = new HashSet<>(reachedNodes.keySet());
+        playerIds.addAll(lastLocatedNodes.keySet());
+        for (UUID id : playerIds) {
+            CompoundTag player = new CompoundTag();
+            player.putUUID("Id", id);
+            ListTag reached = new ListTag();
+            reachedNodes.getOrDefault(id, Set.of()).stream()
+                    .map(String::valueOf)
+                    .map(StringTag::valueOf)
+                    .forEach(reached::add);
+            player.put("Reached", reached);
+            Long last = lastLocatedNodes.get(id);
+            if (last != null) {
+                player.putLong("Last", last);
+            }
+            players.add(player);
+        }
+        tag.put("Players", players);
+        return tag;
+    }
+
+    private static Optional<NodeType> parseType(String name) {
+        for (NodeType type : NodeType.values()) {
+            if (type.getSerializedName().equals(name)) {
+                return Optional.of(type);
+            }
+        }
+        return Optional.empty();
+    }
+}

--- a/src/main/java/com/leclowndu93150/thaumaturge/content/aura/node/NodeLocationIndex.java
+++ b/src/main/java/com/leclowndu93150/thaumaturge/content/aura/node/NodeLocationIndex.java
@@ -11,19 +11,16 @@ import java.util.ArrayDeque;
 import java.util.Comparator;
 import java.util.Deque;
 import java.util.EnumMap;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.UUID;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.HolderLookup;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.ListTag;
-import net.minecraft.nbt.StringTag;
 import net.minecraft.nbt.Tag;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.util.datafix.DataFixTypes;
@@ -46,8 +43,6 @@ public final class NodeLocationIndex extends SavedData {
             new SavedData.Factory<>(NodeLocationIndex::new, NodeLocationIndex::load, DataFixTypes.LEVEL);
 
     private final Map<NodeType, Set<Long>> nodes = new EnumMap<>(NodeType.class);
-    private final Map<UUID, Set<Long>> reachedNodes = new HashMap<>();
-    private final Map<UUID, Long> lastLocatedNodes = new HashMap<>();
     private final Deque<Long> legacyChunks = new ArrayDeque<>();
     private boolean migrationInitialized;
     private boolean migrationComplete;
@@ -84,23 +79,15 @@ public final class NodeLocationIndex extends SavedData {
             changed |= positions.remove(packed);
         }
         if (changed) {
-            lastLocatedNodes.values().removeIf(value -> value == packed);
-            reachedNodes.values().forEach(positions -> positions.remove(packed));
             setDirty();
         }
     }
 
-    public Optional<BlockPos> findNearest(UUID playerId, BlockPos origin, NodeType type) {
-        markLastLocatedReached(playerId, origin);
-        Set<Long> reached = reachedNodes.getOrDefault(playerId, Set.of());
-        Optional<Long> nearest = nodes.get(type).stream()
-                .filter(pos -> !reached.contains(pos))
-                .min(Comparator.comparingDouble(pos -> BlockPos.of(pos).distSqr(origin)));
-        nearest.ifPresent(pos -> {
-            lastLocatedNodes.put(playerId, pos);
-            setDirty();
-        });
-        return nearest.map(BlockPos::of);
+    public Optional<BlockPos> findNearest(BlockPos origin, NodeType type) {
+        return nodes.get(type).stream()
+                .filter(pos -> BlockPos.of(pos).distSqr(origin) > REACHED_DISTANCE_SQ)
+                .min(Comparator.comparingDouble(pos -> BlockPos.of(pos).distSqr(origin)))
+                .map(BlockPos::of);
     }
 
     public boolean isMigrationComplete() {
@@ -183,16 +170,6 @@ public final class NodeLocationIndex extends SavedData {
         }
     }
 
-    private void markLastLocatedReached(UUID playerId, BlockPos origin) {
-        Long last = lastLocatedNodes.get(playerId);
-        if (last == null || BlockPos.of(last).distSqr(origin) > REACHED_DISTANCE_SQ) {
-            return;
-        }
-        reachedNodes.computeIfAbsent(playerId, ignored -> new HashSet<>()).add(last);
-        lastLocatedNodes.remove(playerId);
-        setDirty();
-    }
-
     private static NodeLocationIndex load(CompoundTag tag, HolderLookup.Provider registries) {
         NodeLocationIndex index = new NodeLocationIndex();
         index.migrationComplete = tag.getBoolean("LegacyMigrationComplete");
@@ -201,28 +178,6 @@ public final class NodeLocationIndex extends SavedData {
             CompoundTag node = (CompoundTag) value;
             parseType(node.getString("Type"))
                     .ifPresent(type -> index.nodes.get(type).add(node.getLong("Pos")));
-        }
-        ListTag players = tag.getList("Players", Tag.TAG_COMPOUND);
-        for (Tag value : players) {
-            CompoundTag player = (CompoundTag) value;
-            if (!player.hasUUID("Id")) {
-                continue;
-            }
-            UUID id = player.getUUID("Id");
-            Set<Long> reached = new HashSet<>();
-            for (Tag packed : player.getList("Reached", Tag.TAG_STRING)) {
-                try {
-                    reached.add(Long.parseLong(packed.getAsString()));
-                } catch (NumberFormatException ignored) {
-                    // Ignore malformed legacy/user-edited entries.
-                }
-            }
-            if (!reached.isEmpty()) {
-                index.reachedNodes.put(id, reached);
-            }
-            if (player.contains("Last", Tag.TAG_LONG)) {
-                index.lastLocatedNodes.put(id, player.getLong("Last"));
-            }
         }
         return index;
     }
@@ -238,25 +193,6 @@ public final class NodeLocationIndex extends SavedData {
         }));
         tag.put("Nodes", nodeList);
 
-        ListTag players = new ListTag();
-        Set<UUID> playerIds = new HashSet<>(reachedNodes.keySet());
-        playerIds.addAll(lastLocatedNodes.keySet());
-        for (UUID id : playerIds) {
-            CompoundTag player = new CompoundTag();
-            player.putUUID("Id", id);
-            ListTag reached = new ListTag();
-            reachedNodes.getOrDefault(id, Set.of()).stream()
-                    .map(String::valueOf)
-                    .map(StringTag::valueOf)
-                    .forEach(reached::add);
-            player.put("Reached", reached);
-            Long last = lastLocatedNodes.get(id);
-            if (last != null) {
-                player.putLong("Last", last);
-            }
-            players.add(player);
-        }
-        tag.put("Players", players);
         tag.putBoolean("LegacyMigrationComplete", migrationComplete);
         return tag;
     }

--- a/src/main/java/com/leclowndu93150/thaumaturge/content/aura/node/NodeLocationIndex.java
+++ b/src/main/java/com/leclowndu93150/thaumaturge/content/aura/node/NodeLocationIndex.java
@@ -1,7 +1,15 @@
 package com.leclowndu93150.thaumaturge.content.aura.node;
 
 import com.leclowndu93150.thaumaturge.api.nodes.NodeType;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.ArrayDeque;
 import java.util.Comparator;
+import java.util.Deque;
 import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -9,6 +17,8 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.HolderLookup;
 import net.minecraft.nbt.CompoundTag;
@@ -17,18 +27,31 @@ import net.minecraft.nbt.StringTag;
 import net.minecraft.nbt.Tag;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.util.datafix.DataFixTypes;
+import net.minecraft.world.level.ChunkPos;
+import net.minecraft.world.level.chunk.ChunkAccess;
+import net.minecraft.world.level.chunk.LevelChunk;
+import net.minecraft.world.level.chunk.status.ChunkStatus;
+import net.minecraft.world.level.dimension.DimensionType;
 import net.minecraft.world.level.saveddata.SavedData;
+import net.minecraft.world.level.storage.LevelResource;
 
 /** Persistent index used by the node locator command. */
 public final class NodeLocationIndex extends SavedData {
     private static final String DATA_NAME = "thaumaturge_node_locations";
     private static final double REACHED_DISTANCE_SQ = 10.0 * 10.0;
+    private static final Pattern REGION_FILE = Pattern.compile("r\\.(-?\\d+)\\.(-?\\d+)\\.mca");
+    private static final int REGION_HEADER_BYTES = 4096;
+    private static final int LEGACY_CHUNKS_PER_TICK = 2;
     private static final SavedData.Factory<NodeLocationIndex> FACTORY =
             new SavedData.Factory<>(NodeLocationIndex::new, NodeLocationIndex::load, DataFixTypes.LEVEL);
 
     private final Map<NodeType, Set<Long>> nodes = new EnumMap<>(NodeType.class);
     private final Map<UUID, Set<Long>> reachedNodes = new HashMap<>();
     private final Map<UUID, Long> lastLocatedNodes = new HashMap<>();
+    private final Deque<Long> legacyChunks = new ArrayDeque<>();
+    private boolean migrationInitialized;
+    private boolean migrationComplete;
+    private int migrationTotal;
 
     public NodeLocationIndex() {
         for (NodeType type : NodeType.values()) {
@@ -80,6 +103,86 @@ public final class NodeLocationIndex extends SavedData {
         return nearest.map(BlockPos::of);
     }
 
+    public boolean isMigrationComplete() {
+        return migrationComplete;
+    }
+
+    public int migrationRemaining() {
+        return legacyChunks.size();
+    }
+
+    public int migrationTotal() {
+        return migrationTotal;
+    }
+
+    public void tickLegacyMigration(ServerLevel level) {
+        initializeLegacyMigration(level);
+        for (int i = 0; i < LEGACY_CHUNKS_PER_TICK && !legacyChunks.isEmpty(); i++) {
+            ChunkPos pos = new ChunkPos(legacyChunks.removeFirst());
+            // Every queued position came from a non-empty region-file header entry, so this loads
+            // existing terrain without probing or generating coordinates outside the old save.
+            ChunkAccess loaded = level.getChunkSource().getChunk(pos.x, pos.z, ChunkStatus.FULL, true);
+            if (loaded instanceof LevelChunk chunk) {
+                chunk.getBlockEntities().values().stream()
+                        .filter(BlockEntityNode.class::isInstance)
+                        .map(BlockEntityNode.class::cast)
+                        .filter(node ->
+                                node.getBlockState().is(com.leclowndu93150.thaumaturge.registry.TCBlocks.NODE.get()))
+                        .forEach(node -> register(node.getBlockPos(), node.getNodeType()));
+            }
+        }
+        if (legacyChunks.isEmpty() && !migrationComplete) {
+            migrationComplete = true;
+            setDirty();
+        }
+    }
+
+    private void initializeLegacyMigration(ServerLevel level) {
+        if (migrationInitialized || migrationComplete) {
+            return;
+        }
+        migrationInitialized = true;
+        Path root = level.getServer().getWorldPath(LevelResource.ROOT);
+        Path regionDirectory =
+                DimensionType.getStorageFolder(level.dimension(), root).resolve("region");
+        if (!Files.isDirectory(regionDirectory)) {
+            return;
+        }
+        try (var files = Files.list(regionDirectory)) {
+            files.filter(Files::isRegularFile).forEach(this::readRegionHeader);
+        } catch (IOException ignored) {
+            // A later server session can retry if the save directory was temporarily unavailable.
+            migrationInitialized = false;
+            return;
+        }
+        migrationTotal = legacyChunks.size();
+    }
+
+    private void readRegionHeader(Path path) {
+        Matcher matcher = REGION_FILE.matcher(path.getFileName().toString());
+        if (!matcher.matches()) {
+            return;
+        }
+        int regionX = Integer.parseInt(matcher.group(1));
+        int regionZ = Integer.parseInt(matcher.group(2));
+        ByteBuffer header = ByteBuffer.allocate(REGION_HEADER_BYTES);
+        try (FileChannel channel = FileChannel.open(path, StandardOpenOption.READ)) {
+            while (header.hasRemaining() && channel.read(header) >= 0) {
+                // Fill the location table.
+            }
+        } catch (IOException ignored) {
+            return;
+        }
+        header.flip();
+        for (int index = 0; index < 1024 && header.remaining() >= Integer.BYTES; index++) {
+            if (header.getInt() != 0) {
+                int chunkX = regionX * 32 + index % 32;
+                int chunkZ = regionZ * 32 + index / 32;
+                legacyChunks.addLast(ChunkPos.asLong(chunkX, chunkZ));
+            }
+        }
+    }
+
     private void markLastLocatedReached(UUID playerId, BlockPos origin) {
         Long last = lastLocatedNodes.get(playerId);
         if (last == null || BlockPos.of(last).distSqr(origin) > REACHED_DISTANCE_SQ) {
@@ -92,6 +195,7 @@ public final class NodeLocationIndex extends SavedData {
 
     private static NodeLocationIndex load(CompoundTag tag, HolderLookup.Provider registries) {
         NodeLocationIndex index = new NodeLocationIndex();
+        index.migrationComplete = tag.getBoolean("LegacyMigrationComplete");
         ListTag nodeList = tag.getList("Nodes", Tag.TAG_COMPOUND);
         for (Tag value : nodeList) {
             CompoundTag node = (CompoundTag) value;
@@ -153,6 +257,7 @@ public final class NodeLocationIndex extends SavedData {
             players.add(player);
         }
         tag.put("Players", players);
+        tag.putBoolean("LegacyMigrationComplete", migrationComplete);
         return tag;
     }
 

--- a/src/main/java/com/leclowndu93150/thaumaturge/content/aura/node/NodeLocationMigrationEvents.java
+++ b/src/main/java/com/leclowndu93150/thaumaturge/content/aura/node/NodeLocationMigrationEvents.java
@@ -1,0 +1,20 @@
+package com.leclowndu93150.thaumaturge.content.aura.node;
+
+import com.leclowndu93150.thaumaturge.TCIds;
+import net.minecraft.server.level.ServerLevel;
+import net.neoforged.bus.api.SubscribeEvent;
+import net.neoforged.fml.common.EventBusSubscriber;
+import net.neoforged.neoforge.event.tick.LevelTickEvent;
+
+@EventBusSubscriber(modid = TCIds.MODID)
+public final class NodeLocationMigrationEvents {
+    private NodeLocationMigrationEvents() {}
+
+    @SubscribeEvent
+    public static void onLevelTick(LevelTickEvent.Post event) {
+        if (event.getLevel() instanceof ServerLevel level
+                && level.tickRateManager().runsNormally()) {
+            NodeLocationIndex.get(level).tickLegacyMigration(level);
+        }
+    }
+}

--- a/src/main/java/com/leclowndu93150/thaumaturge/server/command/TCCommands.java
+++ b/src/main/java/com/leclowndu93150/thaumaturge/server/command/TCCommands.java
@@ -277,16 +277,14 @@ public final class TCCommands {
                                 .executes(ctx -> grantAspect(ctx, AspectPools.SOFT_CAP))
                                 .then(Commands.argument("amount", IntegerArgumentType.integer(1, 10000))
                                         .executes(ctx ->
-                                                grantAspect(ctx, IntegerArgumentType.getInteger(ctx, "amount"))))));
+                                                grantAspect(ctx, IntegerArgumentType.getInteger(ctx, "amount"))))))
+                .then(Commands.literal("locate")
+                        .requires(source -> source.hasPermission(Commands.LEVEL_GAMEMASTERS))
+                        .then(Commands.literal("node")
+                                .then(Commands.argument("type", StringArgumentType.word())
+                                        .suggests(NODE_LOCATE_TYPES)
+                                        .executes(TCCommands::locateNode))));
         event.getDispatcher().register(tc);
-        event.getDispatcher()
-                .register(Commands.literal("thaumaturge")
-                        .then(Commands.literal("locate")
-                                .requires(source -> source.hasPermission(Commands.LEVEL_GAMEMASTERS))
-                                .then(Commands.literal("node")
-                                        .then(Commands.argument("type", StringArgumentType.word())
-                                                .suggests(NODE_LOCATE_TYPES)
-                                                .executes(TCCommands::locateNode)))));
     }
 
     private static int locateNode(CommandContext<CommandSourceStack> ctx) throws CommandSyntaxException {

--- a/src/main/java/com/leclowndu93150/thaumaturge/server/command/TCCommands.java
+++ b/src/main/java/com/leclowndu93150/thaumaturge/server/command/TCCommands.java
@@ -18,7 +18,9 @@ import com.leclowndu93150.thaumaturge.api.taint.TaintApi;
 import com.leclowndu93150.thaumaturge.api.warp.IPlayerWarp;
 import com.leclowndu93150.thaumaturge.api.warp.WarpHelper;
 import com.leclowndu93150.thaumaturge.api.warp.WarpType;
+import com.leclowndu93150.thaumaturge.content.aura.node.BlockEntityNode;
 import com.leclowndu93150.thaumaturge.content.aura.node.NodeGenerator;
+import com.leclowndu93150.thaumaturge.content.aura.node.NodeLocationIndex;
 import com.leclowndu93150.thaumaturge.content.casters.ItemFocus;
 import com.leclowndu93150.thaumaturge.content.effect.StreamPathfinder;
 import com.leclowndu93150.thaumaturge.content.eldritch.maze.MazeSavedData;
@@ -66,7 +68,9 @@ import net.minecraft.core.Holder;
 import net.minecraft.core.HolderLookup;
 import net.minecraft.core.Registry;
 import net.minecraft.core.registries.Registries;
+import net.minecraft.network.chat.ClickEvent;
 import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.HoverEvent;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerLevel;
@@ -115,6 +119,8 @@ public final class TCCommands {
             new DynamicCommandExceptionType((value) -> Component.literal("Unknown Research Entry : " + value));
     private static final DynamicCommandExceptionType ERROR_INVALID_ASPECT =
             new DynamicCommandExceptionType((value) -> Component.literal("Unknown Aspect : " + value));
+    private static final DynamicCommandExceptionType ERROR_INVALID_NODE_TYPE =
+            new DynamicCommandExceptionType((value) -> Component.literal("Unknown node type: " + value));
 
     @SubscribeEvent
     public static void onRegister(RegisterCommandsEvent event) {
@@ -273,6 +279,59 @@ public final class TCCommands {
                                         .executes(ctx ->
                                                 grantAspect(ctx, IntegerArgumentType.getInteger(ctx, "amount"))))));
         event.getDispatcher().register(tc);
+        event.getDispatcher()
+                .register(Commands.literal("thaumaturge")
+                        .then(Commands.literal("locate")
+                                .requires(source -> source.hasPermission(Commands.LEVEL_GAMEMASTERS))
+                                .then(Commands.literal("node")
+                                        .then(Commands.argument("type", StringArgumentType.word())
+                                                .suggests(NODE_LOCATE_TYPES)
+                                                .executes(TCCommands::locateNode)))));
+    }
+
+    private static int locateNode(CommandContext<CommandSourceStack> ctx) throws CommandSyntaxException {
+        ServerPlayer player = ctx.getSource().getPlayerOrException();
+        ServerLevel level = player.serverLevel();
+        String typeName = StringArgumentType.getString(ctx, "type");
+        NodeType type = Arrays.stream(NodeType.values())
+                .filter(candidate -> candidate.getSerializedName().equalsIgnoreCase(typeName))
+                .findFirst()
+                .orElseThrow(() -> ERROR_INVALID_NODE_TYPE.create(typeName));
+
+        NodeLocationIndex index = NodeLocationIndex.get(level);
+        BlockPos origin = player.blockPosition();
+        Optional<BlockPos> result;
+        while ((result = index.findNearest(player.getUUID(), origin, type)).isPresent()) {
+            BlockPos candidate = result.get();
+            if (!level.hasChunkAt(candidate)) {
+                break;
+            }
+            if (level.getBlockEntity(candidate) instanceof BlockEntityNode node && node.getNodeType() == type) {
+                break;
+            }
+            index.remove(candidate);
+        }
+        if (result.isEmpty()) {
+            ctx.getSource().sendFailure(Component.literal("No indexed " + type.getSerializedName() + " node found"));
+            return 0;
+        }
+
+        BlockPos pos = result.get();
+        String teleport = "/tp @s " + pos.getX() + " " + pos.getY() + " " + pos.getZ();
+        Component coordinates = Component.literal("[" + pos.getX() + ", " + pos.getY() + ", " + pos.getZ() + "]")
+                .withStyle(style -> style.withColor(ChatFormatting.GREEN)
+                        .withUnderlined(true)
+                        .withClickEvent(new ClickEvent(ClickEvent.Action.SUGGEST_COMMAND, teleport))
+                        .withHoverEvent(new HoverEvent(
+                                HoverEvent.Action.SHOW_TEXT, Component.literal("Click to copy " + teleport))));
+        int distance = (int) Math.round(Math.sqrt(pos.distSqr(origin)));
+        ctx.getSource()
+                .sendSuccess(
+                        () -> Component.literal("Nearest " + type.getSerializedName() + " node is at ")
+                                .append(coordinates)
+                                .append(Component.literal(" (" + distance + " blocks away)")),
+                        false);
+        return Command.SINGLE_SUCCESS;
     }
 
     private static int resetResearch(CommandContext<CommandSourceStack> ctx) {
@@ -925,6 +984,10 @@ public final class TCCommands {
         builder.suggest("random");
         return builder.buildFuture();
     };
+
+    private static final SuggestionProvider<CommandSourceStack> NODE_LOCATE_TYPES =
+            (ctx, builder) -> SharedSuggestionProvider.suggest(
+                    Arrays.stream(NodeType.values()).map(NodeType::getSerializedName), builder);
 
     private static final SuggestionProvider<CommandSourceStack> NODE_MODIFIERS = (ctx, builder) -> {
         for (NodeModifier modifier : NodeModifier.values()) {

--- a/src/main/java/com/leclowndu93150/thaumaturge/server/command/TCCommands.java
+++ b/src/main/java/com/leclowndu93150/thaumaturge/server/command/TCCommands.java
@@ -309,7 +309,7 @@ public final class TCCommands {
         }
         BlockPos origin = player.blockPosition();
         Optional<BlockPos> result;
-        while ((result = index.findNearest(player.getUUID(), origin, type)).isPresent()) {
+        while ((result = index.findNearest(origin, type)).isPresent()) {
             BlockPos candidate = result.get();
             if (!level.hasChunkAt(candidate)) {
                 break;

--- a/src/main/java/com/leclowndu93150/thaumaturge/server/command/TCCommands.java
+++ b/src/main/java/com/leclowndu93150/thaumaturge/server/command/TCCommands.java
@@ -299,6 +299,14 @@ public final class TCCommands {
                 .orElseThrow(() -> ERROR_INVALID_NODE_TYPE.create(typeName));
 
         NodeLocationIndex index = NodeLocationIndex.get(level);
+        if (!index.isMigrationComplete()) {
+            int total = index.migrationTotal();
+            int scanned = Math.max(0, total - index.migrationRemaining());
+            ctx.getSource()
+                    .sendFailure(Component.literal(
+                            "Indexing nodes in existing chunks: " + scanned + "/" + total + ". Try again shortly."));
+            return 0;
+        }
         BlockPos origin = player.blockPosition();
         Optional<BlockPos> result;
         while ((result = index.findNearest(player.getUUID(), origin, type)).isPresent()) {


### PR DESCRIPTION
Adds /tc locate node <type>. It indexes nodes in new and existing worlds, returns the nearest matching node with clickable teleport coordinates, and skips nodes within 10 blocks so the command can locate the next one.