### PR TITLE
[1.21.1][Feature] Make aura node spawning configurable

### DIFF
--- a/src/main/java/com/leclowndu93150/thaumaturge/config/ThaumaturgeCommonConfig.java
+++ b/src/main/java/com/leclowndu93150/thaumaturge/config/ThaumaturgeCommonConfig.java
@@ -10,6 +10,14 @@ public final class ThaumaturgeCommonConfig {
     public static final ModConfigSpec.IntValue TAINT_SPREAD_AREA;
     public static final ModConfigSpec.DoubleValue ENERGIZED_NODE_VIS_PER_POINT;
     public static final ModConfigSpec.IntValue CRIMSON_PORTAL_RARITY;
+    public static final ModConfigSpec.DoubleValue WILD_NODE_CHANCE;
+    public static final ModConfigSpec.DoubleValue MAGICAL_NODE_CHANCE;
+    public static final ModConfigSpec.DoubleValue EERIE_NODE_CHANCE;
+    public static final ModConfigSpec.DoubleValue NETHER_NODE_CHANCE;
+    public static final ModConfigSpec.DoubleValue DARK_NODE_CHANCE;
+    public static final ModConfigSpec.DoubleValue UNSTABLE_NODE_CHANCE;
+    public static final ModConfigSpec.DoubleValue PURE_NODE_CHANCE;
+    public static final ModConfigSpec.DoubleValue HUNGRY_NODE_CHANCE;
     public static final ModConfigSpec.IntValue SHIELD_RECHARGE;
     public static final ModConfigSpec.IntValue SHIELD_WAIT;
     public static final ModConfigSpec.DoubleValue SHIELD_COST;
@@ -35,6 +43,32 @@ public final class ThaumaturgeCommonConfig {
         CRIMSON_PORTAL_RARITY = builder.comment(
                         "Average number of chunks per wild lesser crimson portal. Higher is rarer. 0 disables wild portals entirely.")
                 .defineInRange("crimsonPortalRarity", 500, 0, 1000000);
+        builder.push("nodes");
+        WILD_NODE_CHANCE = builder.comment(
+                        "Chance from 0 to 100 for a wild node placement attempt in each Overworld chunk. 4 means 4%, or about one attempt per 25 chunks. 0 disables this source.")
+                .defineInRange("wildSpawnChance", 4.0, 0.0, 100.0);
+        MAGICAL_NODE_CHANCE = builder.comment(
+                        "Additional chance from 0 to 100 in each Magical Forest chunk. This stacks with wildSpawnChance. 8.333 means roughly one additional attempt per 12 chunks.")
+                .defineInRange("magicalBonusSpawnChance", 100.0 / 12.0, 0.0, 100.0);
+        EERIE_NODE_CHANCE = builder.comment(
+                        "Additional chance from 0 to 100 in each Eerie biome chunk. This stacks with wildSpawnChance and its node is always dark. 12.5 means one attempt per 8 chunks.")
+                .defineInRange("eerieBonusSpawnChance", 12.5, 0.0, 100.0);
+        NETHER_NODE_CHANCE = builder.comment(
+                        "Chance from 0 to 100 for a node placement attempt in each Nether chunk. 2.5 means one attempt per 40 chunks. 0 disables Nether nodes.")
+                .defineInRange("netherSpawnChance", 2.5, 0.0, 100.0);
+        builder.comment(
+                        "The following values are percentages among ordinary random nodes. Their default total is 6.6667%, leaving 93.3333% normal nodes. If their total exceeds 100, they are treated as relative weights and normal nodes become 0%.")
+                .push("types");
+        DARK_NODE_CHANCE = builder.comment("Dark-node percentage, from 0 to 100. Default: 2%.")
+                .defineInRange("darkChance", 2.0, 0.0, 100.0);
+        UNSTABLE_NODE_CHANCE = builder.comment("Unstable-node percentage, from 0 to 100. Default: 2%.")
+                .defineInRange("unstableChance", 2.0, 0.0, 100.0);
+        PURE_NODE_CHANCE = builder.comment("Pure-node percentage, from 0 to 100. Default: 2%.")
+                .defineInRange("pureChance", 2.0, 0.0, 100.0);
+        HUNGRY_NODE_CHANCE = builder.comment(
+                        "Hungry-node percentage, from 0 to 100. Default: 0.6667%, approximately one hungry node per 150 ordinary nodes.")
+                .defineInRange("hungryChance", 2.0 / 3.0, 0.0, 100.0);
+        builder.pop(2);
         SHIELD_RECHARGE = builder.comment("Ticks between each point of runic shielding recharge.")
                 .defineInRange("shieldRecharge", 40, 1, 12000);
         SHIELD_WAIT = builder.comment("Ticks runic shielding waits before recharging after being fully depleted.")

--- a/src/main/java/com/leclowndu93150/thaumaturge/content/aura/node/NodeGenerator.java
+++ b/src/main/java/com/leclowndu93150/thaumaturge/content/aura/node/NodeGenerator.java
@@ -8,6 +8,7 @@ import com.leclowndu93150.thaumaturge.api.aura.BiomeAspects;
 import com.leclowndu93150.thaumaturge.api.aura.BiomeAuraModifier;
 import com.leclowndu93150.thaumaturge.api.nodes.NodeModifier;
 import com.leclowndu93150.thaumaturge.api.nodes.NodeType;
+import com.leclowndu93150.thaumaturge.config.ThaumaturgeCommonConfig;
 import com.leclowndu93150.thaumaturge.registry.TCBlocks;
 import com.leclowndu93150.thaumaturge.registry.TCDataMaps;
 import java.util.ArrayList;
@@ -85,13 +86,8 @@ public final class NodeGenerator {
             type = NodeType.PURE;
         } else if (eerie) {
             type = NodeType.DARK;
-        } else if (random.nextInt(specialRarity) == 0) {
-            type = switch (random.nextInt(10)) {
-                case 0, 1, 2 -> NodeType.DARK;
-                case 3, 4, 5 -> NodeType.UNSTABLE;
-                case 6, 7, 8 -> NodeType.PURE;
-                default -> NodeType.HUNGRY;
-            };
+        } else {
+            type = rollConfiguredType(random);
         }
 
         NodeModifier modifier = null;
@@ -153,6 +149,28 @@ public final class NodeGenerator {
         }
 
         return new NodeData(type, Optional.ofNullable(modifier), distributed, distributed);
+    }
+
+    private static NodeType rollConfiguredType(RandomSource random) {
+        double dark = ThaumaturgeCommonConfig.DARK_NODE_CHANCE.get();
+        double unstable = ThaumaturgeCommonConfig.UNSTABLE_NODE_CHANCE.get();
+        double pure = ThaumaturgeCommonConfig.PURE_NODE_CHANCE.get();
+        double hungry = ThaumaturgeCommonConfig.HUNGRY_NODE_CHANCE.get();
+        double specialTotal = dark + unstable + pure + hungry;
+        double roll = random.nextDouble() * Math.max(100.0, specialTotal);
+        if ((roll -= dark) < 0.0) {
+            return NodeType.DARK;
+        }
+        if ((roll -= unstable) < 0.0) {
+            return NodeType.UNSTABLE;
+        }
+        if ((roll -= pure) < 0.0) {
+            return NodeType.PURE;
+        }
+        if (roll < hungry) {
+            return NodeType.HUNGRY;
+        }
+        return NodeType.NORMAL;
     }
 
     public static boolean createNodeAt(

--- a/src/main/java/com/leclowndu93150/thaumaturge/content/world/objects/ConfigNodeSpawnFilter.java
+++ b/src/main/java/com/leclowndu93150/thaumaturge/content/world/objects/ConfigNodeSpawnFilter.java
@@ -1,0 +1,65 @@
+package com.leclowndu93150.thaumaturge.content.world.objects;
+
+import com.leclowndu93150.thaumaturge.config.ThaumaturgeCommonConfig;
+import com.leclowndu93150.thaumaturge.registry.TCPlacementModifiers;
+import com.mojang.serialization.MapCodec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import net.minecraft.core.BlockPos;
+import net.minecraft.util.RandomSource;
+import net.minecraft.util.StringRepresentable;
+import net.minecraft.world.level.levelgen.placement.PlacementContext;
+import net.minecraft.world.level.levelgen.placement.PlacementFilter;
+import net.minecraft.world.level.levelgen.placement.PlacementModifierType;
+
+public final class ConfigNodeSpawnFilter extends PlacementFilter {
+    public static final MapCodec<ConfigNodeSpawnFilter> CODEC = RecordCodecBuilder.mapCodec(
+            instance -> instance.group(Kind.CODEC.fieldOf("kind").forGetter(filter -> filter.kind))
+                    .apply(instance, ConfigNodeSpawnFilter::new));
+
+    public static final ConfigNodeSpawnFilter WILD = new ConfigNodeSpawnFilter(Kind.WILD);
+    public static final ConfigNodeSpawnFilter MAGICAL = new ConfigNodeSpawnFilter(Kind.MAGICAL);
+    public static final ConfigNodeSpawnFilter EERIE = new ConfigNodeSpawnFilter(Kind.EERIE);
+    public static final ConfigNodeSpawnFilter NETHER = new ConfigNodeSpawnFilter(Kind.NETHER);
+
+    private final Kind kind;
+
+    private ConfigNodeSpawnFilter(Kind kind) {
+        this.kind = kind;
+    }
+
+    @Override
+    protected boolean shouldPlace(PlacementContext context, RandomSource random, BlockPos pos) {
+        double chance =
+                switch (kind) {
+                    case WILD -> ThaumaturgeCommonConfig.WILD_NODE_CHANCE.get();
+                    case MAGICAL -> ThaumaturgeCommonConfig.MAGICAL_NODE_CHANCE.get();
+                    case EERIE -> ThaumaturgeCommonConfig.EERIE_NODE_CHANCE.get();
+                    case NETHER -> ThaumaturgeCommonConfig.NETHER_NODE_CHANCE.get();
+                };
+        return chance > 0.0 && random.nextDouble() * 100.0 < chance;
+    }
+
+    @Override
+    public PlacementModifierType<?> type() {
+        return TCPlacementModifiers.NODE_SPAWN_CHANCE.get();
+    }
+
+    public enum Kind implements StringRepresentable {
+        WILD("wild"),
+        MAGICAL("magical"),
+        EERIE("eerie"),
+        NETHER("nether");
+
+        private static final com.mojang.serialization.Codec<Kind> CODEC = StringRepresentable.fromEnum(Kind::values);
+        private final String name;
+
+        Kind(String name) {
+            this.name = name;
+        }
+
+        @Override
+        public String getSerializedName() {
+            return name;
+        }
+    }
+}

--- a/src/main/java/com/leclowndu93150/thaumaturge/data/worldgen/feature/TCPlacedFeatures.java
+++ b/src/main/java/com/leclowndu93150/thaumaturge/data/worldgen/feature/TCPlacedFeatures.java
@@ -1,6 +1,7 @@
 package com.leclowndu93150.thaumaturge.data.worldgen.feature;
 
 import com.leclowndu93150.thaumaturge.TCIds;
+import com.leclowndu93150.thaumaturge.content.world.objects.ConfigNodeSpawnFilter;
 import com.leclowndu93150.thaumaturge.content.world.objects.ConfigRarityFilter;
 import com.leclowndu93150.thaumaturge.registry.TCBlocks;
 import java.util.List;
@@ -57,10 +58,6 @@ public final class TCPlacedFeatures {
     private static final int CINDERPEARL_RARITY = 30;
     private static final int CINDERPEARL_TRIES = 18;
     private static final int CINDERPEARL_XZ_SPREAD = 8;
-    private static final int NODE_WILD_RARITY = 25;
-    private static final int NODE_MAGICAL_RARITY = 12;
-    private static final int NODE_EERIE_RARITY = 8;
-    private static final int NODE_NETHER_RARITY = 40;
     private static final int OBSIDIAN_TOTEM_RARITY = 1440;
     private static final int HILLTOP_STONES_RARITY = 720;
     private static final int NODE_NETHER_MIN_Y = 32;
@@ -165,35 +162,39 @@ public final class TCPlacedFeatures {
                 new PlacedFeature(
                         configured.getOrThrow(TCConfiguredFeatures.NODES_WILD),
                         List.of(
-                                RarityFilter.onAverageOnceEvery(NODE_WILD_RARITY), InSquarePlacement.spread(),
+                                ConfigNodeSpawnFilter.WILD,
+                                InSquarePlacement.spread(),
                                 HeightmapPlacement.onHeightmap(Heightmap.Types.WORLD_SURFACE_WG),
-                                        BiomeFilter.biome())));
+                                BiomeFilter.biome())));
         context.register(
                 NODES_MAGICAL,
                 new PlacedFeature(
                         configured.getOrThrow(TCConfiguredFeatures.NODES_WILD),
                         List.of(
-                                RarityFilter.onAverageOnceEvery(NODE_MAGICAL_RARITY), InSquarePlacement.spread(),
+                                ConfigNodeSpawnFilter.MAGICAL,
+                                InSquarePlacement.spread(),
                                 HeightmapPlacement.onHeightmap(Heightmap.Types.WORLD_SURFACE_WG),
-                                        BiomeFilter.biome())));
+                                BiomeFilter.biome())));
         context.register(
                 NODES_EERIE,
                 new PlacedFeature(
                         configured.getOrThrow(TCConfiguredFeatures.NODES_EERIE),
                         List.of(
-                                RarityFilter.onAverageOnceEvery(NODE_EERIE_RARITY), InSquarePlacement.spread(),
+                                ConfigNodeSpawnFilter.EERIE,
+                                InSquarePlacement.spread(),
                                 HeightmapPlacement.onHeightmap(Heightmap.Types.WORLD_SURFACE_WG),
-                                        BiomeFilter.biome())));
+                                BiomeFilter.biome())));
         context.register(
                 NODES_NETHER,
                 new PlacedFeature(
                         configured.getOrThrow(TCConfiguredFeatures.NODES_WILD),
                         List.of(
-                                RarityFilter.onAverageOnceEvery(NODE_NETHER_RARITY), InSquarePlacement.spread(),
+                                ConfigNodeSpawnFilter.NETHER,
+                                InSquarePlacement.spread(),
                                 HeightRangePlacement.uniform(
-                                                VerticalAnchor.absolute(NODE_NETHER_MIN_Y),
-                                                VerticalAnchor.absolute(NODE_NETHER_MAX_Y)),
-                                        BiomeFilter.biome())));
+                                        VerticalAnchor.absolute(NODE_NETHER_MIN_Y),
+                                        VerticalAnchor.absolute(NODE_NETHER_MAX_Y)),
+                                BiomeFilter.biome())));
 
         context.register(
                 OBSIDIAN_TOTEM,

--- a/src/main/java/com/leclowndu93150/thaumaturge/registry/TCPlacementModifiers.java
+++ b/src/main/java/com/leclowndu93150/thaumaturge/registry/TCPlacementModifiers.java
@@ -1,6 +1,7 @@
 package com.leclowndu93150.thaumaturge.registry;
 
 import com.leclowndu93150.thaumaturge.TCIds;
+import com.leclowndu93150.thaumaturge.content.world.objects.ConfigNodeSpawnFilter;
 import com.leclowndu93150.thaumaturge.content.world.objects.ConfigRarityFilter;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.world.level.levelgen.placement.PlacementModifierType;
@@ -15,6 +16,9 @@ public final class TCPlacementModifiers {
     public static final DeferredHolder<PlacementModifierType<?>, PlacementModifierType<ConfigRarityFilter>>
             CRIMSON_PORTAL_RARITY =
                     PLACEMENT_MODIFIERS.register("crimson_portal_rarity", () -> () -> ConfigRarityFilter.CODEC);
+    public static final DeferredHolder<PlacementModifierType<?>, PlacementModifierType<ConfigNodeSpawnFilter>>
+            NODE_SPAWN_CHANCE =
+                    PLACEMENT_MODIFIERS.register("node_spawn_chance", () -> () -> ConfigNodeSpawnFilter.CODEC);
 
     private TCPlacementModifiers() {}
 


### PR DESCRIPTION
Adds percentage-based config options for node generation frequency and node types. Spawn rates can be configured separately for the Overworld, Magical Forest, Eerie biomes, and Nether, alongside dark, unstable, pure, and hungry node percentages. Defaults preserve the original rates.