### PR TITLE
[1.21.1] [Feature]configurable hungry nodes

### DIFF
--- a/src/main/java/com/leclowndu93150/thaumaturge/config/ThaumaturgeCommonConfig.java
+++ b/src/main/java/com/leclowndu93150/thaumaturge/config/ThaumaturgeCommonConfig.java
@@ -10,6 +10,9 @@ public final class ThaumaturgeCommonConfig {
     public static final ModConfigSpec.IntValue TAINT_SPREAD_AREA;
     public static final ModConfigSpec.DoubleValue ENERGIZED_NODE_VIS_PER_POINT;
     public static final ModConfigSpec.IntValue CRIMSON_PORTAL_RARITY;
+    public static final ModConfigSpec.IntValue HUNGRY_NODE_BLOCK_EAT_RANGE;
+    public static final ModConfigSpec.DoubleValue HUNGRY_NODE_BLOCK_HARDNESS;
+    public static final ModConfigSpec.IntValue HUNGRY_NODE_BLOCK_EAT_INTERVAL;
     public static final ModConfigSpec.IntValue SHIELD_RECHARGE;
     public static final ModConfigSpec.IntValue SHIELD_WAIT;
     public static final ModConfigSpec.DoubleValue SHIELD_COST;
@@ -35,6 +38,15 @@ public final class ThaumaturgeCommonConfig {
         CRIMSON_PORTAL_RARITY = builder.comment(
                         "Average number of chunks per wild lesser crimson portal. Higher is rarer. 0 disables wild portals entirely.")
                 .defineInRange("crimsonPortalRarity", 500, 0, 1000000);
+        HUNGRY_NODE_BLOCK_EAT_RANGE = builder.comment(
+                        "Hungry-node block eating range in blocks. Default: 16. Range: 1 to 64. This does not change entity or item pulling range.")
+                .defineInRange("hungryNodeBlockEatRange", 16, 1, 64);
+        HUNGRY_NODE_BLOCK_HARDNESS = builder.comment(
+                        "Highest block hardness hungry nodes can eat. They eat blocks below this value, not equal to it. Default: 5.0. Range: 0 to 100. 0 disables block destruction.")
+                .defineInRange("hungryNodeBlockEatHardness", 5.0, 0.0, 100.0);
+        HUNGRY_NODE_BLOCK_EAT_INTERVAL = builder.comment(
+                        "Ticks between hungry-node block eating attempts. Default: 50 ticks (2.5 seconds). Range: 1 to 12000. Lower values eat faster; Minecraft normally runs at 20 ticks per second.")
+                .defineInRange("hungryNodeBlockEatInterval", 50, 1, 12000);
         SHIELD_RECHARGE = builder.comment("Ticks between each point of runic shielding recharge.")
                 .defineInRange("shieldRecharge", 40, 1, 12000);
         SHIELD_WAIT = builder.comment("Ticks runic shielding waits before recharging after being fully depleted.")

--- a/src/main/java/com/leclowndu93150/thaumaturge/config/ThaumaturgeCommonConfig.java
+++ b/src/main/java/com/leclowndu93150/thaumaturge/config/ThaumaturgeCommonConfig.java
@@ -11,6 +11,9 @@ public final class ThaumaturgeCommonConfig {
     public static final ModConfigSpec.DoubleValue ENERGIZED_NODE_VIS_PER_POINT;
     public static final ModConfigSpec.IntValue CRIMSON_PORTAL_RARITY;
     public static final ModConfigSpec.IntValue HUNGRY_NODE_BLOCK_EAT_RANGE;
+    public static final ModConfigSpec.BooleanValue SCALE_HUNGRY_NODE_RANGE_BY_MODIFIER;
+    public static final ModConfigSpec.IntValue HUNGRY_NODE_MINIMUM_BLOCK_EAT_RANGE;
+    public static final ModConfigSpec.IntValue HUNGRY_NODE_MAXIMUM_BLOCK_EAT_RANGE;
     public static final ModConfigSpec.DoubleValue HUNGRY_NODE_BLOCK_HARDNESS;
     public static final ModConfigSpec.IntValue HUNGRY_NODE_BLOCK_EAT_INTERVAL;
     public static final ModConfigSpec.IntValue SHIELD_RECHARGE;
@@ -43,6 +46,20 @@ public final class ThaumaturgeCommonConfig {
                         "Default: 16. Range: 1 to 64. A larger area gives each attempt more possible targets; it does not guarantee a distant block will be selected.",
                         "This setting does not change entity or dropped-item pulling range.")
                 .defineInRange("hungryNodeBlockEatRange", 16, 1, 64);
+        SCALE_HUNGRY_NODE_RANGE_BY_MODIFIER = builder.comment(
+                        "Whether a hungry node's block-eating range scales with its current modifier (quality).",
+                        "False: hungryNodeBlockEatRange is always used. True: the minimum/maximum settings below override hungryNodeBlockEatRange.",
+                        "Fading uses the minimum, pale and normal are evenly spaced between them, and bright uses the maximum.")
+                .define("scaleHungryNodeBlockEatRangeByModifier", false);
+        HUNGRY_NODE_MINIMUM_BLOCK_EAT_RANGE = builder.comment(
+                        "Block-eating range of a fading hungry node when modifier scaling is enabled.",
+                        "Default: 16. Range: 1 to 64. This setting does nothing while scaleHungryNodeBlockEatRangeByModifier is false.")
+                .defineInRange("hungryNodeMinimumBlockEatRange", 16, 1, 64);
+        HUNGRY_NODE_MAXIMUM_BLOCK_EAT_RANGE = builder.comment(
+                        "Block-eating range of a bright hungry node when modifier scaling is enabled.",
+                        "Default: 32. Range: 1 to 64. This overrides hungryNodeBlockEatRange while scaling is enabled.",
+                        "If set below the minimum range, the minimum is used for every modifier.")
+                .defineInRange("hungryNodeMaximumBlockEatRange", 32, 1, 64);
         HUNGRY_NODE_BLOCK_HARDNESS = builder.comment(
                         "Maximum block hardness a hungry node can eat. The comparison is strictly below this value, not equal to it.",
                         "Examples: dirt 0.5, stone 1.5, most logs 2, ores/deepslate 3, iron and diamond blocks 5, obsidian 50.",

--- a/src/main/java/com/leclowndu93150/thaumaturge/config/ThaumaturgeCommonConfig.java
+++ b/src/main/java/com/leclowndu93150/thaumaturge/config/ThaumaturgeCommonConfig.java
@@ -39,13 +39,20 @@ public final class ThaumaturgeCommonConfig {
                         "Average number of chunks per wild lesser crimson portal. Higher is rarer. 0 disables wild portals entirely.")
                 .defineInRange("crimsonPortalRarity", 500, 0, 1000000);
         HUNGRY_NODE_BLOCK_EAT_RANGE = builder.comment(
-                        "Hungry-node block eating range in blocks. Default: 16. Range: 1 to 64. This does not change entity or item pulling range.")
+                        "Maximum length in blocks of a hungry node's random block-eating ray.",
+                        "Default: 16. Range: 1 to 64. A larger area gives each attempt more possible targets; it does not guarantee a distant block will be selected.",
+                        "This setting does not change entity or dropped-item pulling range.")
                 .defineInRange("hungryNodeBlockEatRange", 16, 1, 64);
         HUNGRY_NODE_BLOCK_HARDNESS = builder.comment(
-                        "Highest block hardness hungry nodes can eat. They eat blocks below this value, not equal to it. Default: 5.0. Range: 0 to 100. 0 disables block destruction.")
+                        "Maximum block hardness a hungry node can eat. The comparison is strictly below this value, not equal to it.",
+                        "Examples: dirt 0.5, stone 1.5, most logs 2, ores/deepslate 3, iron and diamond blocks 5, obsidian 50.",
+                        "Default: 5.0, so it can eat ordinary terrain and ores, but not hardness-5 metal/gem blocks or obsidian.",
+                        "Range: 0 to 100. 0 disables block destruction. Unbreakable blocks such as bedrock have negative hardness and are never eaten.")
                 .defineInRange("hungryNodeBlockEatHardness", 5.0, 0.0, 100.0);
         HUNGRY_NODE_BLOCK_EAT_INTERVAL = builder.comment(
-                        "Ticks between hungry-node block eating attempts. Default: 50 ticks (2.5 seconds). Range: 1 to 12000. Lower values eat faster; Minecraft normally runs at 20 ticks per second.")
+                        "Ticks between hungry-node block-eating attempts. Minecraft normally runs at 20 ticks per second; lower values are faster.",
+                        "Examples: 1 = 20 attempts/second, 20 = once/second, 50 = once/2.5 seconds, 1200 = once/minute.",
+                        "Default: 50. Range: 1 to 12000. An attempt may miss or hit an ineligible block, so this is not a guaranteed destruction interval.")
                 .defineInRange("hungryNodeBlockEatInterval", 50, 1, 12000);
         SHIELD_RECHARGE = builder.comment("Ticks between each point of runic shielding recharge.")
                 .defineInRange("shieldRecharge", 40, 1, 12000);

--- a/src/main/java/com/leclowndu93150/thaumaturge/content/aura/node/BlockEntityNode.java
+++ b/src/main/java/com/leclowndu93150/thaumaturge/content/aura/node/BlockEntityNode.java
@@ -863,7 +863,7 @@ public class BlockEntityNode extends BlockEntity implements IAspectContainer {
     }
 
     private void eatBlock(ServerLevel serverLevel, BlockPos pos, RandomSource random) {
-        int range = ThaumaturgeCommonConfig.HUNGRY_NODE_BLOCK_EAT_RANGE.get();
+        int range = hungryBlockEatRange();
         int tx = pos.getX() + random.nextInt(range) - random.nextInt(range);
         int ty = pos.getY() + random.nextInt(range) - random.nextInt(range);
         int tz = pos.getZ() + random.nextInt(range) - random.nextInt(range);
@@ -884,6 +884,25 @@ public class BlockEntityNode extends BlockEntity implements IAspectContainer {
         if (!state.isAir() && hardness >= 0.0F && hardness < maxHardness) {
             serverLevel.destroyBlock(target, true);
         }
+    }
+
+    private int hungryBlockEatRange() {
+        if (!ThaumaturgeCommonConfig.SCALE_HUNGRY_NODE_RANGE_BY_MODIFIER.get()) {
+            return ThaumaturgeCommonConfig.HUNGRY_NODE_BLOCK_EAT_RANGE.get();
+        }
+        int minimum = ThaumaturgeCommonConfig.HUNGRY_NODE_MINIMUM_BLOCK_EAT_RANGE.get();
+        int maximum = Math.max(minimum, ThaumaturgeCommonConfig.HUNGRY_NODE_MAXIMUM_BLOCK_EAT_RANGE.get());
+        int difference = maximum - minimum;
+        if (nodeModifier == NodeModifier.BRIGHT) {
+            return maximum;
+        }
+        if (nodeModifier == NodeModifier.PALE) {
+            return minimum + Math.round(difference / 3.0F);
+        }
+        if (nodeModifier == NodeModifier.FADING) {
+            return minimum;
+        }
+        return minimum + Math.round(difference * 2.0F / 3.0F);
     }
 
     public void burstIntoOrbs(ServerLevel serverLevel, BlockPos pos) {
@@ -964,7 +983,7 @@ public class BlockEntityNode extends BlockEntity implements IAspectContainer {
             return;
         }
         RandomSource random = clientLevel.getRandom();
-        int range = ThaumaturgeCommonConfig.HUNGRY_NODE_BLOCK_EAT_RANGE.get();
+        int range = hungryBlockEatRange();
         int tx = pos.getX() + random.nextInt(range) - random.nextInt(range);
         int ty = pos.getY() + random.nextInt(range) - random.nextInt(range);
         int tz = pos.getZ() + random.nextInt(range) - random.nextInt(range);

--- a/src/main/java/com/leclowndu93150/thaumaturge/content/aura/node/BlockEntityNode.java
+++ b/src/main/java/com/leclowndu93150/thaumaturge/content/aura/node/BlockEntityNode.java
@@ -79,10 +79,8 @@ public class BlockEntityNode extends BlockEntity implements IAspectContainer {
     private static final float BRIGHTEN_FLUX_LIMIT = 0.1F;
     private static final float BRIGHTEN_FILL_FRACTION = 0.9F;
     private static final int BRIGHTEN_CHANCE = 50;
-    private static final int HUNGRY_REACH = 16;
     private static final double HUNGRY_PULL_RANGE = 15.0;
     private static final double HUNGRY_EAT_RANGE_SQ = 2.0;
-    private static final float HUNGRY_MAX_HARDNESS = 5.0F;
     private static final int DARK_SPAWN_PLAYER_RANGE = 24;
     private static final int DARK_SPAWN_CAP = 3;
     private static final float PURE_FLUX_CLEANSE = 0.25F;
@@ -748,10 +746,20 @@ public class BlockEntityNode extends BlockEntity implements IAspectContainer {
     }
 
     private boolean handleTypeBehavior(ServerLevel serverLevel, BlockPos pos, boolean change) {
-        if (count % BEHAVIOR_INTERVAL != 0 || !allowTypeBehavior()) {
+        if (!allowTypeBehavior()) {
             return change;
         }
         RandomSource random = serverLevel.getRandom();
+        if (nodeType == NodeType.HUNGRY) {
+            int interval = ThaumaturgeCommonConfig.HUNGRY_NODE_BLOCK_EAT_INTERVAL.get();
+            if (count % interval == 0) {
+                eatBlock(serverLevel, pos, random);
+            }
+            return change;
+        }
+        if (count % BEHAVIOR_INTERVAL != 0) {
+            return change;
+        }
         switch (nodeType) {
             case TAINTED -> {
                 BlockPos target = pos.offset(
@@ -764,7 +772,6 @@ public class BlockEntityNode extends BlockEntity implements IAspectContainer {
             }
             case PURE -> AuraHelper.drainFlux(serverLevel, pos, PURE_FLUX_CLEANSE, false);
             case DARK -> spawnDarkGuard(serverLevel, pos, random);
-            case HUNGRY -> eatBlock(serverLevel, pos, random);
             default -> {}
         }
         return change;
@@ -856,9 +863,10 @@ public class BlockEntityNode extends BlockEntity implements IAspectContainer {
     }
 
     private void eatBlock(ServerLevel serverLevel, BlockPos pos, RandomSource random) {
-        int tx = pos.getX() + random.nextInt(HUNGRY_REACH) - random.nextInt(HUNGRY_REACH);
-        int ty = pos.getY() + random.nextInt(HUNGRY_REACH) - random.nextInt(HUNGRY_REACH);
-        int tz = pos.getZ() + random.nextInt(HUNGRY_REACH) - random.nextInt(HUNGRY_REACH);
+        int range = ThaumaturgeCommonConfig.HUNGRY_NODE_BLOCK_EAT_RANGE.get();
+        int tx = pos.getX() + random.nextInt(range) - random.nextInt(range);
+        int ty = pos.getY() + random.nextInt(range) - random.nextInt(range);
+        int tz = pos.getZ() + random.nextInt(range) - random.nextInt(range);
         Vec3 from = Vec3.atCenterOf(pos);
         Vec3 to = new Vec3(tx + 0.5, ty + 0.5, tz + 0.5);
         BlockHitResult hit = serverLevel.clip(
@@ -867,12 +875,13 @@ public class BlockEntityNode extends BlockEntity implements IAspectContainer {
             return;
         }
         BlockPos target = hit.getBlockPos();
-        if (target.equals(pos) || target.distSqr(pos) > 256.0) {
+        if (target.equals(pos) || target.distSqr(pos) > (double) range * range) {
             return;
         }
         BlockState state = serverLevel.getBlockState(target);
         float hardness = state.getDestroySpeed(serverLevel, target);
-        if (!state.isAir() && hardness >= 0.0F && hardness < HUNGRY_MAX_HARDNESS) {
+        double maxHardness = ThaumaturgeCommonConfig.HUNGRY_NODE_BLOCK_HARDNESS.get();
+        if (!state.isAir() && hardness >= 0.0F && hardness < maxHardness) {
             serverLevel.destroyBlock(target, true);
         }
     }
@@ -955,9 +964,10 @@ public class BlockEntityNode extends BlockEntity implements IAspectContainer {
             return;
         }
         RandomSource random = clientLevel.getRandom();
-        int tx = pos.getX() + random.nextInt(HUNGRY_REACH) - random.nextInt(HUNGRY_REACH);
-        int ty = pos.getY() + random.nextInt(HUNGRY_REACH) - random.nextInt(HUNGRY_REACH);
-        int tz = pos.getZ() + random.nextInt(HUNGRY_REACH) - random.nextInt(HUNGRY_REACH);
+        int range = ThaumaturgeCommonConfig.HUNGRY_NODE_BLOCK_EAT_RANGE.get();
+        int tx = pos.getX() + random.nextInt(range) - random.nextInt(range);
+        int ty = pos.getY() + random.nextInt(range) - random.nextInt(range);
+        int tz = pos.getZ() + random.nextInt(range) - random.nextInt(range);
         Vec3 from = Vec3.atCenterOf(pos);
         Vec3 to = new Vec3(tx + 0.5, ty + 0.5, tz + 0.5);
         BlockHitResult hit = clientLevel.clip(
@@ -966,11 +976,12 @@ public class BlockEntityNode extends BlockEntity implements IAspectContainer {
             return;
         }
         BlockPos target = hit.getBlockPos();
-        if (target.equals(pos) || target.distSqr(pos) > 256.0) {
+        if (target.equals(pos) || target.distSqr(pos) > (double) range * range) {
             return;
         }
         BlockState state = clientLevel.getBlockState(target);
-        if (state.isAir()) {
+        float hardness = state.getDestroySpeed(clientLevel, target);
+        if (state.isAir() || hardness < 0.0F || hardness >= ThaumaturgeCommonConfig.HUNGRY_NODE_BLOCK_HARDNESS.get()) {
             return;
         }
         Vec3 pull = from.subtract(Vec3.atCenterOf(target)).normalize().scale(0.3);


### PR DESCRIPTION
Adds configurable hungry-node block-eating range, hardness, and speed. Optionally scales eating range by node quality, from fading at the configured minimum to bright at the maximum.