### PR TITLE
[1.21.1] Modernize magical plant tags and remove legacy hardcoded checks

### DIFF
--- a/src/main/java/com/leclowndu93150/thaumaturge/content/wands/WandChargingEvents.java
+++ b/src/main/java/com/leclowndu93150/thaumaturge/content/wands/WandChargingEvents.java
@@ -6,12 +6,14 @@ import com.leclowndu93150.thaumaturge.api.aspect.AspectList;
 import com.leclowndu93150.thaumaturge.api.aspect.IAspect;
 import com.leclowndu93150.thaumaturge.api.aspect.TCAspects;
 import com.leclowndu93150.thaumaturge.content.aspect.EntityAspects;
+import com.leclowndu93150.thaumaturge.registry.TCBlockTags;
 import com.leclowndu93150.thaumaturge.registry.TCBlocks;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Holder;
 import net.minecraft.resources.ResourceKey;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.util.RandomSource;
 import net.minecraft.world.entity.LivingEntity;
@@ -59,6 +61,9 @@ public final class WandChargingEvents {
             return;
         }
         ServerLevel level = event.getLevel();
+        if (!event.getState().is(TCBlockTags.MAGICAL_PLANTS)) {
+            return;
+        }
         ResourceKey<IAspect> aspect = plantAspect(event.getState().getBlock());
         if (aspect == null) {
             return;
@@ -75,13 +80,14 @@ public final class WandChargingEvents {
     }
 
     private static ResourceKey<IAspect> plantAspect(Block block) {
-        if (block == TCBlocks.PLANT_CINDERPEARL.get()) {
+        ResourceLocation id = block.builtInRegistryHolder().key().location();
+        if (id.equals(TCBlocks.PLANT_CINDERPEARL.getId())) {
             return TCAspects.IGNIS;
         }
-        if (block == TCBlocks.PLANT_SHIMMERLEAF.get()) {
+        if (id.equals(TCBlocks.PLANT_SHIMMERLEAF.getId())) {
             return TCAspects.ORDO;
         }
-        if (block == TCBlocks.PLANT_VISHROOM.get()) {
+        if (id.equals(TCBlocks.PLANT_VISHROOM.getId())) {
             return TCAspects.PERDITIO;
         }
         return null;

--- a/src/main/java/com/leclowndu93150/thaumaturge/content/world/objects/HilltopStonesFeature.java
+++ b/src/main/java/com/leclowndu93150/thaumaturge/content/world/objects/HilltopStonesFeature.java
@@ -175,7 +175,11 @@ public final class HilltopStonesFeature extends Feature<NoneFeatureConfiguration
         if (isValidGround(ground)) {
             return true;
         }
-        return (ground.is(Blocks.SNOW) || ground.is(Blocks.SHORT_GRASS) || ground.is(BlockTags.SMALL_FLOWERS) || ground.is(TCBlockTags.MAGICAL_PLANTS)) && isValidGround(below);
+        return (ground.is(Blocks.SNOW)
+                        || ground.is(Blocks.SHORT_GRASS)
+                        || ground.is(BlockTags.SMALL_FLOWERS)
+                        || ground.is(TCBlockTags.MAGICAL_PLANTS))
+                && isValidGround(below);
     }
 
     private static boolean isValidGround(BlockState state) {
@@ -189,7 +193,10 @@ public final class HilltopStonesFeature extends Feature<NoneFeatureConfiguration
             if (isValidGround(state)) {
                 return state;
             }
-            if (!state.isAir() && !state.is(Blocks.SNOW) && !state.is(Blocks.SHORT_GRASS) && !state.is(TCBlockTags.MAGICAL_PLANTS)) {
+            if (!state.isAir()
+                    && !state.is(Blocks.SNOW)
+                    && !state.is(Blocks.SHORT_GRASS)
+                    && !state.is(TCBlockTags.MAGICAL_PLANTS)) {
                 break;
             }
             cursor.move(Direction.DOWN);

--- a/src/main/java/com/leclowndu93150/thaumaturge/content/world/objects/HilltopStonesFeature.java
+++ b/src/main/java/com/leclowndu93150/thaumaturge/content/world/objects/HilltopStonesFeature.java
@@ -1,6 +1,7 @@
 package com.leclowndu93150.thaumaturge.content.world.objects;
 
 import com.leclowndu93150.thaumaturge.content.aura.node.NodeGenerator;
+import com.leclowndu93150.thaumaturge.registry.TCBlockTags;
 import com.leclowndu93150.thaumaturge.registry.TCBlocks;
 import com.leclowndu93150.thaumaturge.registry.TCEntities;
 import com.mojang.serialization.Codec;
@@ -67,7 +68,8 @@ public final class HilltopStonesFeature extends Feature<NoneFeatureConfiguration
                         if (below.isAir()
                                 || below.is(Blocks.SNOW)
                                 || below.is(Blocks.SHORT_GRASS)
-                                || below.is(BlockTags.SMALL_FLOWERS)) {
+                                || below.is(BlockTags.SMALL_FLOWERS)
+                                || below.is(TCBlockTags.MAGICAL_PLANTS)) {
                             level.setBlock(cursor, fill, PLACE_FLAGS);
                         }
                     }
@@ -173,7 +175,7 @@ public final class HilltopStonesFeature extends Feature<NoneFeatureConfiguration
         if (isValidGround(ground)) {
             return true;
         }
-        return (ground.is(Blocks.SNOW) || ground.is(Blocks.SHORT_GRASS)) && isValidGround(below);
+        return (ground.is(Blocks.SNOW) || ground.is(Blocks.SHORT_GRASS) || ground.is(BlockTags.SMALL_FLOWERS) || ground.is(TCBlockTags.MAGICAL_PLANTS)) && isValidGround(below);
     }
 
     private static boolean isValidGround(BlockState state) {
@@ -187,7 +189,7 @@ public final class HilltopStonesFeature extends Feature<NoneFeatureConfiguration
             if (isValidGround(state)) {
                 return state;
             }
-            if (!state.isAir() && !state.is(Blocks.SNOW) && !state.is(Blocks.SHORT_GRASS)) {
+            if (!state.isAir() && !state.is(Blocks.SNOW) && !state.is(Blocks.SHORT_GRASS) && !state.is(TCBlockTags.MAGICAL_PLANTS)) {
                 break;
             }
             cursor.move(Direction.DOWN);

--- a/src/main/java/com/leclowndu93150/thaumaturge/content/world/plant/BlockPlantCinderpearl.java
+++ b/src/main/java/com/leclowndu93150/thaumaturge/content/world/plant/BlockPlantCinderpearl.java
@@ -3,10 +3,10 @@ package com.leclowndu93150.thaumaturge.content.world.plant;
 import com.mojang.serialization.MapCodec;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.particles.ParticleTypes;
+import net.minecraft.tags.BlockTags;
 import net.minecraft.util.RandomSource;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Level;
-import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.state.BlockBehaviour;
 import net.minecraft.world.level.block.state.BlockState;
 
@@ -24,26 +24,7 @@ public final class BlockPlantCinderpearl extends AbstractTCPlant {
 
     @Override
     protected boolean mayPlaceOn(BlockState state, BlockGetter level, BlockPos pos) {
-        return state.is(Blocks.SAND)
-                || state.is(Blocks.RED_SAND)
-                || state.is(Blocks.DIRT)
-                || state.is(Blocks.TERRACOTTA)
-                || state.is(Blocks.WHITE_TERRACOTTA)
-                || state.is(Blocks.ORANGE_TERRACOTTA)
-                || state.is(Blocks.MAGENTA_TERRACOTTA)
-                || state.is(Blocks.LIGHT_BLUE_TERRACOTTA)
-                || state.is(Blocks.YELLOW_TERRACOTTA)
-                || state.is(Blocks.LIME_TERRACOTTA)
-                || state.is(Blocks.PINK_TERRACOTTA)
-                || state.is(Blocks.GRAY_TERRACOTTA)
-                || state.is(Blocks.LIGHT_GRAY_TERRACOTTA)
-                || state.is(Blocks.CYAN_TERRACOTTA)
-                || state.is(Blocks.PURPLE_TERRACOTTA)
-                || state.is(Blocks.BLUE_TERRACOTTA)
-                || state.is(Blocks.BROWN_TERRACOTTA)
-                || state.is(Blocks.GREEN_TERRACOTTA)
-                || state.is(Blocks.RED_TERRACOTTA)
-                || state.is(Blocks.BLACK_TERRACOTTA);
+        return state.is(BlockTags.SAND) || state.is(BlockTags.DIRT) || state.is(BlockTags.TERRACOTTA);
     }
 
     @Override

--- a/src/main/java/com/leclowndu93150/thaumaturge/data/tag/TCBlockTagsProvider.java
+++ b/src/main/java/com/leclowndu93150/thaumaturge/data/tag/TCBlockTagsProvider.java
@@ -191,6 +191,11 @@ public final class TCBlockTagsProvider extends BlockTagsProvider {
 
         tag(BlockTags.FLOWERS).add(TCBlocks.PLANT_SHIMMERLEAF.get()).add(TCBlocks.PLANT_CINDERPEARL.get());
 
+        tag(TCBlockTags.MAGICAL_PLANTS)
+                .add(TCBlocks.PLANT_SHIMMERLEAF.get())
+                .add(TCBlocks.PLANT_CINDERPEARL.get())
+                .add(TCBlocks.PLANT_VISHROOM.get());
+
         tag(Tags.Blocks.STRIPPED_LOGS)
                 .add(TCBlocks.STRIPPED_LOG_GREATWOOD.get())
                 .add(TCBlocks.STRIPPED_LOG_SILVERWOOD.get());

--- a/src/main/java/com/leclowndu93150/thaumaturge/data/tag/TCBlockTagsProvider.java
+++ b/src/main/java/com/leclowndu93150/thaumaturge/data/tag/TCBlockTagsProvider.java
@@ -189,6 +189,8 @@ public final class TCBlockTagsProvider extends BlockTagsProvider {
 
         tag(BlockTags.SNAPS_GOAT_HORN).add(TCBlocks.LOG_GREATWOOD.get()).add(TCBlocks.LOG_SILVERWOOD.get());
 
+        tag(BlockTags.FLOWERS).add(TCBlocks.PLANT_SHIMMERLEAF.get()).add(TCBlocks.PLANT_CINDERPEARL.get());
+
         tag(Tags.Blocks.STRIPPED_LOGS)
                 .add(TCBlocks.STRIPPED_LOG_GREATWOOD.get())
                 .add(TCBlocks.STRIPPED_LOG_SILVERWOOD.get());

--- a/src/main/java/com/leclowndu93150/thaumaturge/data/tag/TCItemTagsProvider.java
+++ b/src/main/java/com/leclowndu93150/thaumaturge/data/tag/TCItemTagsProvider.java
@@ -32,6 +32,7 @@ public final class TCItemTagsProvider extends ItemTagsProvider {
         copy(BlockTags.LEAVES, ItemTags.LEAVES);
         copy(BlockTags.SAPLINGS, ItemTags.SAPLINGS);
         copy(BlockTags.PLANKS, ItemTags.PLANKS);
+        copy(BlockTags.FLOWERS, ItemTags.FLOWERS);
         copy(TCBlockTags.GREATWOOD_LOGS, TCItemTags.GREATWOOD_LOGS);
         copy(TCBlockTags.SILVERWOOD_LOGS, TCItemTags.SILVERWOOD_LOGS);
         copy(Tags.Blocks.STRIPPED_LOGS, Tags.Items.STRIPPED_LOGS);

--- a/src/main/java/com/leclowndu93150/thaumaturge/data/tag/TCItemTagsProvider.java
+++ b/src/main/java/com/leclowndu93150/thaumaturge/data/tag/TCItemTagsProvider.java
@@ -33,6 +33,7 @@ public final class TCItemTagsProvider extends ItemTagsProvider {
         copy(BlockTags.SAPLINGS, ItemTags.SAPLINGS);
         copy(BlockTags.PLANKS, ItemTags.PLANKS);
         copy(BlockTags.FLOWERS, ItemTags.FLOWERS);
+        copy(TCBlockTags.MAGICAL_PLANTS, TCItemTags.MAGICAL_PLANTS);
         copy(TCBlockTags.GREATWOOD_LOGS, TCItemTags.GREATWOOD_LOGS);
         copy(TCBlockTags.SILVERWOOD_LOGS, TCItemTags.SILVERWOOD_LOGS);
         copy(Tags.Blocks.STRIPPED_LOGS, Tags.Items.STRIPPED_LOGS);

--- a/src/main/java/com/leclowndu93150/thaumaturge/data/worldgen/scan/ScanEntryBootstrap.java
+++ b/src/main/java/com/leclowndu93150/thaumaturge/data/worldgen/scan/ScanEntryBootstrap.java
@@ -77,19 +77,7 @@ public final class ScanEntryBootstrap {
                 ctx,
                 "plants",
                 "plants",
-                blocks(
-                        blockReg,
-                        concat(
-                                List.of(
-                                        TCBlocks.LOG_GREATWOOD.get(), TCBlocks.LOG_SILVERWOOD.get(),
-                                        TCBlocks.WOOD_GREATWOOD.get(), TCBlocks.WOOD_SILVERWOOD.get(),
-                                        TCBlocks.STRIPPED_LOG_GREATWOOD.get(), TCBlocks.STRIPPED_LOG_SILVERWOOD.get(),
-                                        TCBlocks.STRIPPED_WOOD_GREATWOOD.get(), TCBlocks.STRIPPED_WOOD_SILVERWOOD.get(),
-                                        TCBlocks.SAPLING_GREATWOOD.get(), TCBlocks.SAPLING_SILVERWOOD.get()),
-                                List.of(
-                                        TCBlocks.PLANT_CINDERPEARL.get(),
-                                        TCBlocks.PLANT_SHIMMERLEAF.get(),
-                                        TCBlocks.PLANT_VISHROOM.get()))),
+                blockReg.getOrThrow(TCBlockTags.MAGICAL_PLANTS),
                 null,
                 null);
         register(ctx, "plantwood", "scanned/plantwood", woods, null, null);

--- a/src/main/java/com/leclowndu93150/thaumaturge/data/worldgen/scan/ScanEntryBootstrap.java
+++ b/src/main/java/com/leclowndu93150/thaumaturge/data/worldgen/scan/ScanEntryBootstrap.java
@@ -73,13 +73,7 @@ public final class ScanEntryBootstrap {
                 null,
                 null);
         register(ctx, "orecrystal", "scanned/orecrystal", crystals, null, null);
-        register(
-                ctx,
-                "plants",
-                "plants",
-                blockReg.getOrThrow(TCBlockTags.MAGICAL_PLANTS),
-                null,
-                null);
+        register(ctx, "plants", "plants", blockReg.getOrThrow(TCBlockTags.MAGICAL_PLANTS), null, null);
         register(ctx, "plantwood", "scanned/plantwood", woods, null, null);
 
         register(

--- a/src/main/java/com/leclowndu93150/thaumaturge/registry/TCBlockTags.java
+++ b/src/main/java/com/leclowndu93150/thaumaturge/registry/TCBlockTags.java
@@ -29,6 +29,8 @@ public final class TCBlockTags {
 
     public static final TagKey<Block> LAMP_GROWTH_BLACKLIST = key("lamp_growth_blacklist");
 
+    public static final TagKey<Block> MAGICAL_PLANTS = key("magical_plants");
+
     private TCBlockTags() {}
 
     private static TagKey<Block> key(String path) {

--- a/src/main/java/com/leclowndu93150/thaumaturge/registry/TCBlocks.java
+++ b/src/main/java/com/leclowndu93150/thaumaturge/registry/TCBlocks.java
@@ -1088,7 +1088,6 @@ public final class TCBlocks {
                     .sound(SoundType.GRASS)
                     .lightLevel(state -> 6)
                     .pushReaction(PushReaction.DESTROY)
-                    .randomTicks()
                     .noOcclusion());
 
     public static final DeferredBlock<BlockPlantCinderpearl> PLANT_CINDERPEARL = BLOCKS.registerBlock(
@@ -1101,7 +1100,6 @@ public final class TCBlocks {
                     .sound(SoundType.GRASS)
                     .lightLevel(state -> 8)
                     .pushReaction(PushReaction.DESTROY)
-                    .randomTicks()
                     .noOcclusion());
 
     public static final DeferredBlock<BlockPlantVishroom> PLANT_VISHROOM = BLOCKS.registerBlock(
@@ -1114,7 +1112,6 @@ public final class TCBlocks {
                     .sound(SoundType.GRASS)
                     .lightLevel(state -> 6)
                     .pushReaction(PushReaction.DESTROY)
-                    .randomTicks()
                     .noOcclusion());
 
     public static final DeferredBlock<BlockGrassAmbient> GRASS_AMBIENT = BLOCKS.registerBlock(

--- a/src/main/java/com/leclowndu93150/thaumaturge/registry/TCItemTags.java
+++ b/src/main/java/com/leclowndu93150/thaumaturge/registry/TCItemTags.java
@@ -60,6 +60,8 @@ public final class TCItemTags {
 
     public static final TagKey<Item> CANDLES = key("candles");
 
+    public static final TagKey<Item> MAGICAL_PLANTS = key("magical_plants");
+
     private TCItemTags() {}
 
     private static TagKey<Item> key(String path) {


### PR DESCRIPTION
- Add Shimmerleaf and Cinderpearl to #minecraft:flowers (block + item)
- Introduce thaumaturge:magical_plants tag covering all three magical plants
- Migrate WandChargingEvents, ScanEntryBootstrap, and HilltopStonesFeature to use the new tag instead of hardcoded block identity checks
- Remove unused .randomTicks() from Shimmerleaf, Cinderpearl, and Vishroom (no growth logic exists and Growth Lamp does not target BushBlock)
- Modernize Cinderpearl mayPlaceOn to use BlockTags.SAND, BlockTags.DIRT, and BlockTags.TERRACOTTA instead of 20 hardcoded state checks