### PR TITLE
Fix Nitor rendering and add filtered-aspect tinting to Filter Tubes

### DIFF
--- a/src/main/java/com/leclowndu93150/thaumaturge/client/color/TubeFilterBlockColors.java
+++ b/src/main/java/com/leclowndu93150/thaumaturge/client/color/TubeFilterBlockColors.java
@@ -1,0 +1,38 @@
+package com.leclowndu93150.thaumaturge.client.color;
+
+import com.leclowndu93150.thaumaturge.TCIds;
+import com.leclowndu93150.thaumaturge.api.aspect.AspectList;
+import com.leclowndu93150.thaumaturge.content.essentia.tube.BlockEntityTubeFilter;
+import com.leclowndu93150.thaumaturge.registry.TCBlocks;
+import net.minecraft.client.color.block.BlockColor;
+import net.neoforged.api.distmarker.Dist;
+import net.neoforged.bus.api.SubscribeEvent;
+import net.neoforged.fml.common.EventBusSubscriber;
+import net.neoforged.neoforge.client.event.RegisterColorHandlersEvent;
+
+@EventBusSubscriber(modid = TCIds.MODID, value = Dist.CLIENT)
+public final class TubeFilterBlockColors {
+    private static final int UNFILTERED = 0xFFFFFFFF;
+
+    private TubeFilterBlockColors() {}
+
+    @SubscribeEvent
+    public static void onRegisterBlockColors(RegisterColorHandlersEvent.Block event) {
+        BlockColor color = (state, level, pos, tintIndex) -> {
+            if (tintIndex != 1 || level == null || pos == null) {
+                return UNFILTERED;
+            }
+            if (!(level.getBlockEntity(pos) instanceof BlockEntityTubeFilter filter)) {
+                return UNFILTERED;
+            }
+
+            AspectList advertised = filter.queryAspects();
+            if (advertised.isEmpty()) {
+                return UNFILTERED;
+            }
+
+            return 0xFF000000 | (advertised.entries().get(0).aspect().value().color() & 0xFFFFFF);
+        };
+        event.register(color, TCBlocks.TUBE_FILTER.get());
+    }
+}

--- a/src/main/java/com/leclowndu93150/thaumaturge/client/particle/NitorCoreParticle.java
+++ b/src/main/java/com/leclowndu93150/thaumaturge/client/particle/NitorCoreParticle.java
@@ -61,7 +61,7 @@ public final class NitorCoreParticle extends SingleQuadParticle {
 
     @Override
     public ParticleRenderType getRenderType() {
-        return TCParticleLayers.additive(this.sheet);
+        return TCParticleLayers.translucentNoDepth(this.sheet);
     }
 
     @Override

--- a/src/main/java/com/leclowndu93150/thaumaturge/client/particle/TCParticle.java
+++ b/src/main/java/com/leclowndu93150/thaumaturge/client/particle/TCParticle.java
@@ -164,6 +164,6 @@ public abstract class TCParticle extends SingleQuadParticle {
 
     @Override
     public ParticleRenderType getRenderType() {
-        return this.sheet != null ? TCParticleLayers.additive(this.sheet) : ParticleRenderType.TERRAIN_SHEET;
+        return this.sheet != null ? TCParticleLayers.additiveNoDepth(this.sheet) : ParticleRenderType.TERRAIN_SHEET;
     }
 }


### PR DESCRIPTION
Nitors are still rendering incorrectly. The changes introduced in #208 caused the core to render more "proeminently" than the 26.1.2 version, the `additiveNoDepth` makes it render "invisible" since it blends with the particles. To stay closer to 26.1.2, it was changed to use `translucentNoDepth` (if the goal is to make the core invisible, then `additiveNoDepth` is probably a better choice).
`getRenderType` in `TCParticles` was also changed to use additiveNoDepth. I tested other particles that use this class to render and didn't notice any changes in how they render, but it is probably good to have some more tests.

<img width="1400" height="379" alt="image" src="https://github.com/user-attachments/assets/3b686a4c-d2c4-4204-a6f2-96e26fec24ef" />

 `TubeFilterBlockColors` was added to render the aspect tint in Filter Tubes

<img width="811" height="629" alt="image" src="https://github.com/user-attachments/assets/0cf911ca-b097-42ec-85b1-b4d34723fdc2" />
