### PR TITLE
[1.21.1] render: modernize beam and portal effects

### DIFF
--- a/src/main/java/com/leclowndu93150/thaumaturge/client/effect/FloatyLineRenderer.java
+++ b/src/main/java/com/leclowndu93150/thaumaturge/client/effect/FloatyLineRenderer.java
@@ -51,7 +51,7 @@ public final class FloatyLineRenderer {
                 width);
     }
 
-    private static void write(
+    static void write(
             PoseStack.Pose pose,
             VertexConsumer buffer,
             Vec3 fromRelative,

--- a/src/main/java/com/leclowndu93150/thaumaturge/client/effect/LateWorldRenderQueue.java
+++ b/src/main/java/com/leclowndu93150/thaumaturge/client/effect/LateWorldRenderQueue.java
@@ -30,7 +30,11 @@ public final class LateWorldRenderQueue {
 
     @SubscribeEvent
     public static void onRender(RenderLevelStageEvent event) {
-        if (event.getStage() != RenderLevelStageEvent.Stage.AFTER_WEATHER || QUEUE.isEmpty()) {
+        if (event.getStage() != RenderLevelStageEvent.Stage.AFTER_WEATHER) {
+            return;
+        }
+        OccludingEffectRenderer.render(event);
+        if (QUEUE.isEmpty()) {
             return;
         }
         Minecraft mc = Minecraft.getInstance();

--- a/src/main/java/com/leclowndu93150/thaumaturge/client/effect/OccludingEffectRenderer.java
+++ b/src/main/java/com/leclowndu93150/thaumaturge/client/effect/OccludingEffectRenderer.java
@@ -1,0 +1,125 @@
+package com.leclowndu93150.thaumaturge.client.effect;
+
+import com.leclowndu93150.thaumaturge.TCIds;
+import com.leclowndu93150.thaumaturge.client.render.TCRenderTypes;
+import com.mojang.blaze3d.vertex.PoseStack;
+import com.mojang.blaze3d.vertex.VertexConsumer;
+import java.util.ArrayList;
+import java.util.List;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.renderer.MultiBufferSource;
+import net.minecraft.client.renderer.RenderType;
+import net.minecraft.client.renderer.texture.OverlayTexture;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.phys.Vec3;
+import net.neoforged.neoforge.client.event.RenderLevelStageEvent;
+import org.joml.Matrix4f;
+
+public final class OccludingEffectRenderer {
+    private static final ResourceLocation WISPY_TEXTURE = TCIds.rl("textures/misc/wispy.png");
+    private static final ResourceLocation PORTAL_TEXTURE = TCIds.rl("textures/misc/cultist_portal.png");
+
+    private static final RenderType WISPY = TCRenderTypes.occludingEffect(WISPY_TEXTURE);
+    private static final RenderType PORTAL = TCRenderTypes.occludingEffect(PORTAL_TEXTURE);
+
+    private static final List<Beam> BEAMS = new ArrayList<>();
+    private static final List<Portal> PORTALS = new ArrayList<>();
+
+    private record Beam(
+            Vec3 origin, Vec3 fromRelative, float time, int color, float speed, float distanceFraction, float width) {}
+
+    private record Portal(Vec3 origin, float scaleX, float scaleY, float u0, float u1, int tint, int light) {}
+
+    private OccludingEffectRenderer() {}
+
+    public static void enqueueBeam(
+            Vec3 origin, Vec3 fromRelative, float time, int color, float speed, float distanceFraction, float width) {
+        BEAMS.add(new Beam(origin, fromRelative, time, color, speed, distanceFraction, width));
+    }
+
+    public static void enqueuePortal(Vec3 origin, float scaleX, float scaleY, float u0, float u1, int tint, int light) {
+        PORTALS.add(new Portal(origin, scaleX, scaleY, u0, u1, tint, light));
+    }
+
+    static void render(RenderLevelStageEvent event) {
+        if (BEAMS.isEmpty() && PORTALS.isEmpty()) {
+            return;
+        }
+        Minecraft mc = Minecraft.getInstance();
+        MultiBufferSource.BufferSource buffers = mc.renderBuffers().bufferSource();
+        PoseStack poseStack = event.getPoseStack();
+        Vec3 camera = mc.gameRenderer.getMainCamera().getPosition();
+        try {
+            renderBeams(poseStack, buffers, camera, WISPY);
+            renderPortals(poseStack, buffers, camera, PORTAL);
+        } finally {
+            BEAMS.clear();
+            PORTALS.clear();
+        }
+    }
+
+    private static void renderBeams(
+            PoseStack poseStack, MultiBufferSource.BufferSource buffers, Vec3 camera, RenderType renderType) {
+        if (BEAMS.isEmpty()) {
+            return;
+        }
+        VertexConsumer buffer = buffers.getBuffer(renderType);
+        for (Beam beam : BEAMS) {
+            poseStack.pushPose();
+            poseStack.translate(beam.origin.x - camera.x, beam.origin.y - camera.y, beam.origin.z - camera.z);
+            FloatyLineRenderer.write(
+                    poseStack.last(),
+                    buffer,
+                    beam.fromRelative,
+                    beam.time,
+                    beam.color,
+                    beam.speed,
+                    beam.distanceFraction,
+                    beam.width);
+            poseStack.popPose();
+        }
+        buffers.endBatch(renderType);
+    }
+
+    private static void renderPortals(
+            PoseStack poseStack, MultiBufferSource.BufferSource buffers, Vec3 camera, RenderType renderType) {
+        if (PORTALS.isEmpty()) {
+            return;
+        }
+        VertexConsumer buffer = buffers.getBuffer(renderType);
+        for (Portal portal : PORTALS) {
+            poseStack.pushPose();
+            poseStack.translate(portal.origin.x - camera.x, portal.origin.y - camera.y, portal.origin.z - camera.z);
+            poseStack.mulPose(
+                    Minecraft.getInstance().getEntityRenderDispatcher().cameraOrientation());
+            writePortal(poseStack.last(), buffer, portal);
+            poseStack.popPose();
+        }
+        buffers.endBatch(renderType);
+    }
+
+    private static void writePortal(PoseStack.Pose pose, VertexConsumer buffer, Portal portal) {
+        Matrix4f matrix = pose.pose();
+        portalVertex(pose, buffer, matrix, -portal.scaleX, -portal.scaleY, portal.u1, 0.0F, portal);
+        portalVertex(pose, buffer, matrix, -portal.scaleX, portal.scaleY, portal.u1, 1.0F, portal);
+        portalVertex(pose, buffer, matrix, portal.scaleX, portal.scaleY, portal.u0, 1.0F, portal);
+        portalVertex(pose, buffer, matrix, portal.scaleX, -portal.scaleY, portal.u0, 0.0F, portal);
+    }
+
+    private static void portalVertex(
+            PoseStack.Pose pose,
+            VertexConsumer buffer,
+            Matrix4f matrix,
+            float x,
+            float y,
+            float u,
+            float v,
+            Portal portal) {
+        buffer.addVertex(matrix, x, y, 0.0F)
+                .setUv(u, v)
+                .setColor(portal.tint)
+                .setOverlay(OverlayTexture.NO_OVERLAY)
+                .setLight(portal.light)
+                .setNormal(pose, 0.0F, 0.0F, -1.0F);
+    }
+}

--- a/src/main/java/com/leclowndu93150/thaumaturge/client/effect/OccludingEffectRenderer.java
+++ b/src/main/java/com/leclowndu93150/thaumaturge/client/effect/OccludingEffectRenderer.java
@@ -11,6 +11,7 @@ import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.client.renderer.RenderType;
 import net.minecraft.client.renderer.texture.OverlayTexture;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.entity.Entity;
 import net.minecraft.world.phys.Vec3;
 import net.neoforged.neoforge.client.event.RenderLevelStageEvent;
 import org.joml.Matrix4f;
@@ -33,12 +34,31 @@ public final class OccludingEffectRenderer {
     private OccludingEffectRenderer() {}
 
     public static void enqueueBeam(
-            Vec3 origin, Vec3 fromRelative, float time, int color, float speed, float distanceFraction, float width) {
+            Vec3 cullOrigin,
+            Vec3 origin,
+            Vec3 fromRelative,
+            float time,
+            int color,
+            float speed,
+            float distanceFraction,
+            float width) {
+        if (!isWithinEntityRenderDistance(cullOrigin)) {
+            return;
+        }
         BEAMS.add(new Beam(origin, fromRelative, time, color, speed, distanceFraction, width));
     }
 
     public static void enqueuePortal(Vec3 origin, float scaleX, float scaleY, float u0, float u1, int tint, int light) {
+        if (!isWithinEntityRenderDistance(origin)) {
+            return;
+        }
         PORTALS.add(new Portal(origin, scaleX, scaleY, u0, u1, tint, light));
+    }
+
+    private static boolean isWithinEntityRenderDistance(Vec3 origin) {
+        Vec3 camera = Minecraft.getInstance().gameRenderer.getMainCamera().getPosition();
+        double range = 64.0 * Entity.getViewScale();
+        return camera.distanceToSqr(origin) < range * range;
     }
 
     static void render(RenderLevelStageEvent event) {

--- a/src/main/java/com/leclowndu93150/thaumaturge/client/entity/CultistClericRenderer.java
+++ b/src/main/java/com/leclowndu93150/thaumaturge/client/entity/CultistClericRenderer.java
@@ -70,6 +70,7 @@ public final class CultistClericRenderer
         super.render(entity, entityYaw, partialTicks, poseStack, buffers, light);
         poseStack.popPose();
         OccludingEffectRenderer.enqueueBeam(
+                position,
                 new Vec3(anchor.getX() + 0.5, anchor.getY() + LINE_END_HEIGHT, anchor.getZ() + 0.5),
                 clericFromAltar,
                 time,

--- a/src/main/java/com/leclowndu93150/thaumaturge/client/entity/CultistClericRenderer.java
+++ b/src/main/java/com/leclowndu93150/thaumaturge/client/entity/CultistClericRenderer.java
@@ -2,6 +2,7 @@ package com.leclowndu93150.thaumaturge.client.entity;
 
 import com.leclowndu93150.thaumaturge.TCIds;
 import com.leclowndu93150.thaumaturge.client.effect.FloatyLineRenderer;
+import com.leclowndu93150.thaumaturge.client.effect.OccludingEffectRenderer;
 import com.leclowndu93150.thaumaturge.content.entity.EntityCultistCleric;
 import com.mojang.blaze3d.vertex.PoseStack;
 import net.minecraft.client.model.HumanoidModel;
@@ -67,10 +68,15 @@ public final class CultistClericRenderer
         poseStack.pushPose();
         poseStack.translate(0.0F, bob, 0.0F);
         super.render(entity, entityYaw, partialTicks, poseStack, buffers, light);
-        poseStack.translate(altarFromEntity.x, altarFromEntity.y, altarFromEntity.z);
-        FloatyLineRenderer.draw(
-                poseStack, buffers, clericFromAltar, time, LINE_COLOR, LINE_SPEED, lineFade, LINE_WIDTH);
         poseStack.popPose();
+        OccludingEffectRenderer.enqueueBeam(
+                new Vec3(anchor.getX() + 0.5, anchor.getY() + LINE_END_HEIGHT, anchor.getZ() + 0.5),
+                clericFromAltar,
+                time,
+                LINE_COLOR,
+                LINE_SPEED,
+                lineFade,
+                LINE_WIDTH);
     }
 
     @Override

--- a/src/main/java/com/leclowndu93150/thaumaturge/client/entity/CultistPortalGreaterRenderer.java
+++ b/src/main/java/com/leclowndu93150/thaumaturge/client/entity/CultistPortalGreaterRenderer.java
@@ -27,9 +27,8 @@ public final class CultistPortalGreaterRenderer extends EntityRenderer<EntityCul
             MultiBufferSource buffers,
             int packedLight) {
         super.render(entity, entityYaw, partialTicks, poseStack, buffers, packedLight);
-        CultistPortalRenderer.renderPortal(
-                poseStack,
-                buffers,
+        CultistPortalRenderer.queuePortal(
+                entity.getPosition(partialTicks),
                 true,
                 entity.tickCount + partialTicks,
                 entity.hurtTime,

--- a/src/main/java/com/leclowndu93150/thaumaturge/client/entity/CultistPortalRenderer.java
+++ b/src/main/java/com/leclowndu93150/thaumaturge/client/entity/CultistPortalRenderer.java
@@ -1,23 +1,19 @@
 package com.leclowndu93150.thaumaturge.client.entity;
 
 import com.leclowndu93150.thaumaturge.TCIds;
-import com.leclowndu93150.thaumaturge.client.render.TCRenderTypes;
+import com.leclowndu93150.thaumaturge.client.effect.OccludingEffectRenderer;
 import com.leclowndu93150.thaumaturge.content.entity.EntityCultistPortalLesser;
 import com.mojang.blaze3d.vertex.PoseStack;
-import com.mojang.blaze3d.vertex.VertexConsumer;
-import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.MultiBufferSource;
-import net.minecraft.client.renderer.RenderType;
 import net.minecraft.client.renderer.entity.EntityRenderer;
 import net.minecraft.client.renderer.entity.EntityRendererProvider;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.util.FastColor.ARGB32;
 import net.minecraft.util.Mth;
-import org.joml.Matrix4f;
+import net.minecraft.world.phys.Vec3;
 
 public final class CultistPortalRenderer extends EntityRenderer<EntityCultistPortalLesser> {
     private static final ResourceLocation TEXTURE = TCIds.rl("textures/misc/cultist_portal.png");
-    private static final RenderType PORTAL_TYPE = TCRenderTypes.fxTranslucentDepth(TEXTURE);
 
     private static final int FRAMES = 16;
     private static final float FRAME_WIDTH = 0.0625F;
@@ -40,9 +36,8 @@ public final class CultistPortalRenderer extends EntityRenderer<EntityCultistPor
             MultiBufferSource buffers,
             int packedLight) {
         super.render(entity, entityYaw, partialTicks, poseStack, buffers, packedLight);
-        renderPortal(
-                poseStack,
-                buffers,
+        queuePortal(
+                entity.getPosition(partialTicks),
                 entity.isActive(),
                 entity.activeCounter + partialTicks,
                 entity.hurtTime,
@@ -58,9 +53,8 @@ public final class CultistPortalRenderer extends EntityRenderer<EntityCultistPor
         return TEXTURE;
     }
 
-    static void renderPortal(
-            PoseStack poseStack,
-            MultiBufferSource buffers,
+    static void queuePortal(
+            Vec3 position,
             boolean active,
             float activeCounter,
             int hurtTime,
@@ -95,17 +89,6 @@ public final class CultistPortalRenderer extends EntityRenderer<EntityCultistPor
         float u0 = frame * FRAME_WIDTH;
         float u1 = u0 + FRAME_WIDTH;
         int tint = ARGB32.colorFromFloat(alpha, 1.0F, 1.0F, 1.0F);
-        float sx = scale;
-        float sy = scaleY;
-        poseStack.pushPose();
-        poseStack.translate(0.0F, halfHeight, 0.0F);
-        poseStack.mulPose(Minecraft.getInstance().getEntityRenderDispatcher().cameraOrientation());
-        VertexConsumer buffer = buffers.getBuffer(PORTAL_TYPE);
-        Matrix4f mat = poseStack.last().pose();
-        buffer.addVertex(mat, -sx, -sy, 0.0F).setUv(u1, 0.0F).setColor(tint).setLight(LIGHT);
-        buffer.addVertex(mat, -sx, sy, 0.0F).setUv(u1, 1.0F).setColor(tint).setLight(LIGHT);
-        buffer.addVertex(mat, sx, sy, 0.0F).setUv(u0, 1.0F).setColor(tint).setLight(LIGHT);
-        buffer.addVertex(mat, sx, -sy, 0.0F).setUv(u0, 0.0F).setColor(tint).setLight(LIGHT);
-        poseStack.popPose();
+        OccludingEffectRenderer.enqueuePortal(position.add(0.0, halfHeight, 0.0), scale, scaleY, u0, u1, tint, LIGHT);
     }
 }

--- a/src/main/java/com/leclowndu93150/thaumaturge/client/render/TCRenderTypes.java
+++ b/src/main/java/com/leclowndu93150/thaumaturge/client/render/TCRenderTypes.java
@@ -16,6 +16,8 @@ public final class TCRenderTypes {
             new RenderStateShard.ShaderStateShard(GameRenderer::getParticleShader);
     private static final RenderStateShard.ShaderStateShard POSITION_TEX_COLOR_SHADER =
             new RenderStateShard.ShaderStateShard(GameRenderer::getPositionTexColorShader);
+    private static final RenderStateShard.ShaderStateShard OCCLUDING_EFFECT_SHADER =
+            new RenderStateShard.ShaderStateShard(TCShaders::occludingEffect);
     private static final RenderStateShard.OverlayStateShard OVERLAY = new RenderStateShard.OverlayStateShard(true);
 
     private static final Function<ResourceLocation, RenderType> FX_ADDITIVE = Util.memoize(texture -> particle(
@@ -82,6 +84,23 @@ public final class TCRenderTypes {
             RenderStateShard.LEQUAL_DEPTH_TEST,
             RenderStateShard.COLOR_DEPTH_WRITE,
             false));
+    private static final Function<ResourceLocation, RenderType> OCCLUDING_EFFECT =
+            Util.memoize(texture -> RenderType.create(
+                    "tc_occluding_effect",
+                    DefaultVertexFormat.NEW_ENTITY,
+                    VertexFormat.Mode.QUADS,
+                    BUFFER,
+                    false,
+                    true,
+                    RenderType.CompositeState.builder()
+                            .setShaderState(OCCLUDING_EFFECT_SHADER)
+                            .setTextureState(new RenderStateShard.TextureStateShard(texture, false, false))
+                            .setTransparencyState(RenderStateShard.TRANSLUCENT_TRANSPARENCY)
+                            .setDepthTestState(RenderStateShard.LEQUAL_DEPTH_TEST)
+                            .setWriteMaskState(RenderStateShard.COLOR_DEPTH_WRITE)
+                            .setCullState(RenderStateShard.NO_CULL)
+                            .setOverlayState(OVERLAY)
+                            .createCompositeState(false)));
     private static final Function<ResourceLocation, RenderType> ENTITY_TRANSLUCENT_FLAT = Util.memoize(texture -> flat(
             "tc_entity_translucent_flat",
             texture,
@@ -177,6 +196,10 @@ public final class TCRenderTypes {
 
     public static RenderType entityCutoutFlat(ResourceLocation texture) {
         return ENTITY_CUTOUT_FLAT.apply(texture);
+    }
+
+    public static RenderType occludingEffect(ResourceLocation texture) {
+        return OCCLUDING_EFFECT.apply(texture);
     }
 
     public static RenderType entityTranslucentFlat(ResourceLocation texture) {

--- a/src/main/java/com/leclowndu93150/thaumaturge/client/render/TCShaders.java
+++ b/src/main/java/com/leclowndu93150/thaumaturge/client/render/TCShaders.java
@@ -12,6 +12,7 @@ import net.neoforged.neoforge.client.event.RegisterShadersEvent;
 @EventBusSubscriber(modid = TCIds.MODID, value = Dist.CLIENT)
 public final class TCShaders {
     private static ShaderInstance ender;
+    private static ShaderInstance occludingEffect;
     private static ShaderInstance portal;
     private static ShaderInstance voidStream;
 
@@ -19,6 +20,10 @@ public final class TCShaders {
 
     public static ShaderInstance ender() {
         return ender;
+    }
+
+    public static ShaderInstance occludingEffect() {
+        return occludingEffect;
     }
 
     public static ShaderInstance portal() {
@@ -34,6 +39,10 @@ public final class TCShaders {
         event.registerShader(
                 new ShaderInstance(event.getResourceProvider(), TCIds.rl("tc_ender"), DefaultVertexFormat.POSITION),
                 shader -> ender = shader);
+        event.registerShader(
+                new ShaderInstance(
+                        event.getResourceProvider(), TCIds.rl("tc_occluding_effect"), DefaultVertexFormat.NEW_ENTITY),
+                shader -> occludingEffect = shader);
         event.registerShader(
                 new ShaderInstance(
                         event.getResourceProvider(), TCIds.rl("tc_portal"), DefaultVertexFormat.POSITION_TEX),

--- a/src/main/resources/assets/thaumaturge/shaders/core/tc_occluding_effect.fsh
+++ b/src/main/resources/assets/thaumaturge/shaders/core/tc_occluding_effect.fsh
@@ -1,0 +1,29 @@
+#version 150
+
+#moj_import <fog.glsl>
+
+uniform sampler2D Sampler0;
+
+uniform vec4 ColorModulator;
+uniform float FogStart;
+uniform float FogEnd;
+
+in float vertexDistance;
+in vec4 vertexColor;
+in vec4 overlayColor;
+in vec2 texCoord0;
+
+out vec4 fragColor;
+
+const float EDGE_ALPHA_CUTOFF = 0.05;
+const float OPAQUE_ALPHA_CUTOFF = 0.4;
+
+void main() {
+    vec4 color = texture(Sampler0, texCoord0) * vertexColor * ColorModulator;
+    if (color.a < EDGE_ALPHA_CUTOFF) {
+        discard;
+    }
+    color.rgb = mix(overlayColor.rgb, color.rgb, overlayColor.a);
+    color.a = smoothstep(EDGE_ALPHA_CUTOFF, OPAQUE_ALPHA_CUTOFF, color.a);
+    fragColor = color * linear_fog_fade(vertexDistance, FogStart, FogEnd);
+}

--- a/src/main/resources/assets/thaumaturge/shaders/core/tc_occluding_effect.json
+++ b/src/main/resources/assets/thaumaturge/shaders/core/tc_occluding_effect.json
@@ -1,0 +1,17 @@
+{
+    "vertex": "rendertype_entity_translucent_emissive",
+    "fragment": "thaumaturge:tc_occluding_effect",
+    "samplers": [
+        { "name": "Sampler0" },
+        { "name": "Sampler1" }
+    ],
+    "uniforms": [
+        { "name": "ModelViewMat", "type": "matrix4x4", "count": 16, "values": [ 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0 ] },
+        { "name": "ProjMat", "type": "matrix4x4", "count": 16, "values": [ 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0 ] },
+        { "name": "ColorModulator", "type": "float", "count": 4, "values": [ 1.0, 1.0, 1.0, 1.0 ] },
+        { "name": "Light0_Direction", "type": "float", "count": 3, "values": [ 0.0, 0.0, 0.0 ] },
+        { "name": "Light1_Direction", "type": "float", "count": 3, "values": [ 0.0, 0.0, 0.0 ] },
+        { "name": "FogStart", "type": "float", "count": 1, "values": [ 0.0 ] },
+        { "name": "FogEnd", "type": "float", "count": 1, "values": [ 1.0 ] }
+    ]
+}


### PR DESCRIPTION
modernizes cultist beam and portal rendering with a batched lateworld pass and a custom occluding transparency shader, this prevents background entities and block entities from bleeding through solid-looking areas.