### PR TITLE
[1.21.1] Modernize Jade support

### DIFF
--- a/src/main/java/com/leclowndu93150/thaumaturge/compat/jade/EssentiaComponentProvider.java
+++ b/src/main/java/com/leclowndu93150/thaumaturge/compat/jade/EssentiaComponentProvider.java
@@ -101,20 +101,16 @@ public enum EssentiaComponentProvider implements IBlockComponentProvider {
         } else {
             if (contents.entries().size() == 1 && capacity > 0 && !singleCapacityStorage) {
                 AspectInstance entry = contents.entries().get(0);
-                tooltip.add(
-                        Component.translatable(
-                                "jade.thaumaturge.essentia.combined",
-                                AspectComponents.name(entry.aspect()),
-                                entry.amount(),
-                                capacity));
+                tooltip.add(Component.translatable(
+                        "jade.thaumaturge.essentia.combined",
+                        AspectComponents.name(entry.aspect()),
+                        entry.amount(),
+                        capacity));
             } else {
                 JadeComponents.addAspectLines(tooltip, "jade.thaumaturge.essentia.contents", contents);
                 if (capacity > 0 && !singleCapacityStorage) {
-                    tooltip.add(
-                            Component.translatable(
-                                    "jade.thaumaturge.essentia.amount",
-                                    contents.totalAmount(),
-                                    capacity));
+                    tooltip.add(Component.translatable(
+                            "jade.thaumaturge.essentia.amount", contents.totalAmount(), capacity));
                 }
             }
         }

--- a/src/main/java/com/leclowndu93150/thaumaturge/compat/jade/EssentiaComponentProvider.java
+++ b/src/main/java/com/leclowndu93150/thaumaturge/compat/jade/EssentiaComponentProvider.java
@@ -1,6 +1,8 @@
 package com.leclowndu93150.thaumaturge.compat.jade;
 
 import com.leclowndu93150.thaumaturge.TCIds;
+import com.leclowndu93150.thaumaturge.api.aspect.AspectComponents;
+import com.leclowndu93150.thaumaturge.api.aspect.AspectInstance;
 import com.leclowndu93150.thaumaturge.api.aspect.AspectList;
 import net.minecraft.ChatFormatting;
 import net.minecraft.nbt.CompoundTag;
@@ -97,10 +99,23 @@ public enum EssentiaComponentProvider implements IBlockComponentProvider {
                                     ? Component.translatable("jade.thaumaturge.essentia.empty_capacity", capacity)
                                     : Component.translatable("jade.thaumaturge.essentia.empty"));
         } else {
-            JadeComponents.addAspectLines(tooltip, "jade.thaumaturge.essentia.contents", contents);
-            if (capacity > 0 && !singleCapacityStorage) {
+            if (contents.entries().size() == 1 && capacity > 0 && !singleCapacityStorage) {
+                AspectInstance entry = contents.entries().get(0);
                 tooltip.add(
-                        Component.translatable("jade.thaumaturge.essentia.amount", contents.totalAmount(), capacity));
+                        Component.translatable(
+                                "jade.thaumaturge.essentia.combined",
+                                AspectComponents.name(entry.aspect()),
+                                entry.amount(),
+                                capacity));
+            } else {
+                JadeComponents.addAspectLines(tooltip, "jade.thaumaturge.essentia.contents", contents);
+                if (capacity > 0 && !singleCapacityStorage) {
+                    tooltip.add(
+                            Component.translatable(
+                                    "jade.thaumaturge.essentia.amount",
+                                    contents.totalAmount(),
+                                    capacity));
+                }
             }
         }
     }

--- a/src/main/java/com/leclowndu93150/thaumaturge/compat/jade/EssentiaComponentProvider.java
+++ b/src/main/java/com/leclowndu93150/thaumaturge/compat/jade/EssentiaComponentProvider.java
@@ -1,18 +1,16 @@
 package com.leclowndu93150.thaumaturge.compat.jade;
 
 import com.leclowndu93150.thaumaturge.TCIds;
-import com.leclowndu93150.thaumaturge.api.aspect.AspectComponents;
-import com.leclowndu93150.thaumaturge.api.aspect.AspectInstance;
 import com.leclowndu93150.thaumaturge.api.aspect.AspectList;
-import com.leclowndu93150.thaumaturge.api.aspect.IAspectContainer;
-import com.leclowndu93150.thaumaturge.api.essentia.IAspectQuery;
-import com.leclowndu93150.thaumaturge.content.aura.node.BlockEntityNode;
-import com.leclowndu93150.thaumaturge.content.essentia.jar.BlockEntityJar;
+import net.minecraft.ChatFormatting;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.Tag;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
 import snownee.jade.api.BlockAccessor;
 import snownee.jade.api.IBlockComponentProvider;
 import snownee.jade.api.ITooltip;
+import snownee.jade.api.JadeIds;
 import snownee.jade.api.config.IPluginConfig;
 
 public enum EssentiaComponentProvider implements IBlockComponentProvider {
@@ -26,41 +24,171 @@ public enum EssentiaComponentProvider implements IBlockComponentProvider {
     }
 
     @Override
+    public boolean isRequired() {
+        return true;
+    }
+
+    @Override
+    public int getDefaultPriority() {
+        return 1100;
+    }
+
+    @Override
     public void appendTooltip(ITooltip tooltip, BlockAccessor accessor, IPluginConfig config) {
-        if (accessor.getBlockEntity() instanceof BlockEntityJar jar) {
-            AspectList contents = jar.getContents(accessor.getLevel().registryAccess());
-            if (contents.isEmpty()) {
-                tooltip.add(Component.translatable("jade.thaumaturge.essentia.empty"));
-                return;
-            }
-            for (AspectInstance entry : contents.entries()) {
-                tooltip.add(Component.translatable(
-                        "jade.thaumaturge.essentia.fill",
-                        AspectComponents.name(entry.aspect()),
-                        entry.amount(),
-                        jar.capacity()));
-            }
+        CompoundTag data = accessor.getServerData();
+        if (!data.getBoolean(EssentiaDataProvider.PRESENT)) return;
+        String area = data.getString(EssentiaDataProvider.AREA);
+        ResourceLocation option = optionFor(area);
+        if (option == null) return;
+        boolean crucible = "crucible".equals(area);
+        boolean show = JadeConfig.shouldShow(config, option, accessor);
+        if (!show) {
+            if (crucible) tooltip.remove(JadeIds.UNIVERSAL_FLUID_STORAGE);
             return;
         }
-        if (accessor.getBlockEntity() instanceof BlockEntityNode) {
-            return;
+
+        String tubeKind = data.getString(EssentiaDataProvider.TUBE_KIND);
+        if (crucible) {
+            appendCrucible(tooltip, accessor, data);
+        } else {
+            if (tubeKind.isEmpty() || accessor.showDetails()) appendEssentia(tooltip, accessor, data);
+            if (!tubeKind.isEmpty()) appendTubeState(tooltip, accessor, data, tubeKind);
         }
-        if (accessor.getBlockEntity() instanceof IAspectContainer container) {
-            AspectList aspects = container.getAspects();
-            if (!aspects.isEmpty()) {
-                tooltip.add(JadeComponents.aspectLine("jade.thaumaturge.essentia.contents", aspects));
-            }
-            return;
+
+        if (data.getBoolean(EssentiaDataProvider.HAS_FILTER)) {
+            String filter = data.getString(EssentiaDataProvider.FILTER);
+            tooltip.add(
+                    filter.isEmpty()
+                            ? Component.translatable("jade.thaumaturge.essentia.unfiltered")
+                            : Component.translatable(
+                                    "jade.thaumaturge.essentia.filter",
+                                    JadeComponents.aspectName(
+                                            filter, accessor.getLevel().registryAccess())));
         }
-        if (accessor.getBlockEntity() instanceof IAspectQuery query) {
-            AspectList advertised = query.queryAspects();
-            if (advertised.isEmpty()) {
-                tooltip.add(Component.translatable("jade.thaumaturge.essentia.unfiltered"));
-                return;
-            }
+
+        if (data.contains(EssentiaDataProvider.RECIPE_CAPACITY)) {
             tooltip.add(Component.translatable(
-                    "jade.thaumaturge.essentia.filter",
-                    AspectComponents.name(advertised.entries().getFirst().aspect())));
+                    "jade.thaumaturge.thaumatorium.recipes",
+                    data.getInt(EssentiaDataProvider.RECIPE_COUNT),
+                    data.getInt(EssentiaDataProvider.RECIPE_CAPACITY)));
         }
+
+        if ("centrifuge".equals(area)) {
+            tooltip.add(Component.translatable(
+                    "jade.thaumaturge.centrifuge.state",
+                    Component.translatable(
+                            data.getBoolean(EssentiaDataProvider.ACTIVE)
+                                    ? "jade.thaumaturge.state.processing"
+                                    : "jade.thaumaturge.state.idle")));
+        }
+    }
+
+    private static void appendEssentia(ITooltip tooltip, BlockAccessor accessor, CompoundTag data) {
+        AspectList contents = JadeComponents.decodeAspects(
+                data.getList(EssentiaDataProvider.CONTENTS, Tag.TAG_COMPOUND),
+                accessor.getLevel().registryAccess());
+        int capacity = data.getInt(EssentiaDataProvider.CAPACITY);
+        boolean singleCapacityStorage = capacity == 1;
+        if (contents.isEmpty()) {
+            tooltip.add(
+                    singleCapacityStorage
+                            ? Component.translatable("jade.thaumaturge.essentia.none")
+                            : capacity > 0
+                                    ? Component.translatable("jade.thaumaturge.essentia.empty_capacity", capacity)
+                                    : Component.translatable("jade.thaumaturge.essentia.empty"));
+        } else {
+            JadeComponents.addAspectLines(tooltip, "jade.thaumaturge.essentia.contents", contents);
+            if (capacity > 0 && !singleCapacityStorage) {
+                tooltip.add(
+                        Component.translatable("jade.thaumaturge.essentia.amount", contents.totalAmount(), capacity));
+            }
+        }
+    }
+
+    private static void appendCrucible(ITooltip tooltip, BlockAccessor accessor, CompoundTag data) {
+        int heat = data.getInt(EssentiaDataProvider.CRUCIBLE_HEAT);
+        String state = heat > 150 ? "boiling" : heat > 0 ? "heating" : "cold";
+        tooltip.add(Component.translatable("jade.thaumaturge.crucible.state." + state));
+
+        AspectList contents = JadeComponents.decodeAspects(
+                data.getList(EssentiaDataProvider.CONTENTS, Tag.TAG_COMPOUND),
+                accessor.getLevel().registryAccess());
+        if (!contents.isEmpty()) {
+            JadeComponents.addAspectLines(tooltip, "jade.thaumaturge.essentia.contents", contents);
+        }
+    }
+
+    private static void appendTubeState(ITooltip tooltip, BlockAccessor accessor, CompoundTag data, String tubeKind) {
+        if ("valve".equals(tubeKind)) {
+            boolean open = data.getBoolean(EssentiaDataProvider.VALVE_OPEN);
+            tooltip.add(Component.translatable("jade.thaumaturge.tube.valve." + (open ? "open" : "closed"))
+                    .withStyle(open ? ChatFormatting.GREEN : ChatFormatting.RED));
+        } else if ("oneway".equals(tubeKind)) {
+            tooltip.add(Component.translatable(
+                    "jade.thaumaturge.tube.direction",
+                    JadeComponents.direction(data.getString(EssentiaDataProvider.FACING))));
+        } else if ("restrict".equals(tubeKind)) {
+            tooltip.add(Component.translatable("jade.thaumaturge.tube.restricted"));
+        }
+
+        if (!accessor.showDetails()) return;
+
+        int suction = data.getInt(EssentiaDataProvider.SUCTION);
+        if (suction > 0) {
+            String suctionAspect = data.getString(EssentiaDataProvider.SUCTION_ASPECT);
+            Component type = suctionAspect.isEmpty()
+                    ? Component.translatable("jade.thaumaturge.tube.any_aspect")
+                    : JadeComponents.aspectName(
+                            suctionAspect, accessor.getLevel().registryAccess());
+            tooltip.add(Component.translatable("jade.thaumaturge.tube.suction", type, suction));
+        }
+
+        int closed = data.getInt(EssentiaDataProvider.CLOSED_SIDES);
+        if (closed != 0) {
+            tooltip.add(
+                    Component.translatable("jade.thaumaturge.tube.closed_sides", JadeComponents.directions(closed)));
+        }
+
+        if ("buffer".equals(tubeKind)) {
+            appendChokedSides(tooltip, data.getByteArray(EssentiaDataProvider.CHOKED_SIDES));
+        }
+    }
+
+    private static void appendChokedSides(ITooltip tooltip, byte[] choked) {
+        int partial = 0;
+        int blocked = 0;
+        for (int i = 0; i < Math.min(choked.length, 6); i++) {
+            if (choked[i] == 1) partial |= 1 << i;
+            if (choked[i] >= 2) blocked |= 1 << i;
+        }
+        if (partial != 0) {
+            tooltip.add(Component.translatable(
+                    "jade.thaumaturge.tube.choked",
+                    JadeComponents.directions(partial),
+                    Component.translatable("jade.thaumaturge.tube.choke.reduced")));
+        }
+        if (blocked != 0) {
+            tooltip.add(Component.translatable(
+                    "jade.thaumaturge.tube.choked",
+                    JadeComponents.directions(blocked),
+                    Component.translatable("jade.thaumaturge.tube.choke.blocked")));
+        }
+    }
+
+    private static ResourceLocation optionFor(String area) {
+        return switch (area) {
+            case "jar" -> JadeConfig.JARS;
+            case "alembic" -> JadeConfig.ALEMBICS;
+            case "crucible" -> JadeConfig.CRUCIBLES;
+            case "tube" -> JadeConfig.TUBES;
+            case "valve" -> JadeConfig.VALVES;
+            case "restrict" -> JadeConfig.RESTRICTED_TUBES;
+            case "filter" -> JadeConfig.FILTER_TUBES;
+            case "oneway" -> JadeConfig.ONE_WAY_TUBES;
+            case "buffer" -> JadeConfig.BUFFERS;
+            case "thaumatorium" -> JadeConfig.THAUMATORIUMS;
+            case "centrifuge" -> JadeConfig.CENTRIFUGES;
+            default -> null;
+        };
     }
 }

--- a/src/main/java/com/leclowndu93150/thaumaturge/compat/jade/EssentiaDataProvider.java
+++ b/src/main/java/com/leclowndu93150/thaumaturge/compat/jade/EssentiaDataProvider.java
@@ -1,0 +1,211 @@
+package com.leclowndu93150.thaumaturge.compat.jade;
+
+import com.leclowndu93150.thaumaturge.TCIds;
+import com.leclowndu93150.thaumaturge.api.aspect.AspectInstance;
+import com.leclowndu93150.thaumaturge.api.aspect.AspectList;
+import com.leclowndu93150.thaumaturge.api.aspect.IAspect;
+import com.leclowndu93150.thaumaturge.api.aspect.IAspectContainer;
+import com.leclowndu93150.thaumaturge.api.essentia.IAspectQuery;
+import com.leclowndu93150.thaumaturge.content.aura.node.BlockEntityNode;
+import com.leclowndu93150.thaumaturge.content.crucible.BlockEntityCrucible;
+import com.leclowndu93150.thaumaturge.content.essentia.BlockEntityCentrifuge;
+import com.leclowndu93150.thaumaturge.content.essentia.jar.BlockEntityJar;
+import com.leclowndu93150.thaumaturge.content.essentia.smeltery.BlockEntityAlembic;
+import com.leclowndu93150.thaumaturge.content.essentia.thaumatorium.BlockEntityThaumatorium;
+import com.leclowndu93150.thaumaturge.content.essentia.tube.BlockEntityTube;
+import com.leclowndu93150.thaumaturge.content.essentia.tube.BlockEntityTubeBuffer;
+import com.leclowndu93150.thaumaturge.content.essentia.tube.BlockEntityTubeFilter;
+import com.leclowndu93150.thaumaturge.content.essentia.tube.BlockEntityTubeOneway;
+import com.leclowndu93150.thaumaturge.content.essentia.tube.BlockEntityTubeRestrict;
+import com.leclowndu93150.thaumaturge.content.essentia.tube.BlockEntityTubeValve;
+import net.minecraft.core.Direction;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.ListTag;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import snownee.jade.api.BlockAccessor;
+import snownee.jade.api.IServerDataProvider;
+
+public enum EssentiaDataProvider implements IServerDataProvider<BlockAccessor> {
+    INSTANCE;
+
+    private static final ResourceLocation UID = TCIds.rl("essentia");
+
+    static final String PRESENT = "ThaumaturgeEssentia";
+    static final String AREA = "EssentiaArea";
+    static final String CONTENTS = "EssentiaContents";
+    static final String CAPACITY = "EssentiaCapacity";
+    static final String HAS_FILTER = "HasEssentiaFilter";
+    static final String FILTER = "EssentiaFilter";
+    static final String TUBE_KIND = "TubeKind";
+    static final String FACING = "TubeFacing";
+    static final String CLOSED_SIDES = "TubeClosedSides";
+    static final String CHOKED_SIDES = "TubeChokedSides";
+    static final String VALVE_OPEN = "TubeValveOpen";
+    static final String SUCTION = "TubeSuction";
+    static final String SUCTION_ASPECT = "TubeSuctionAspect";
+    static final String CRUCIBLE_HEAT = "CrucibleHeat";
+    static final String RECIPE_COUNT = "RecipeCount";
+    static final String RECIPE_CAPACITY = "RecipeCapacity";
+    static final String ACTIVE = "EssentiaActive";
+
+    static final String ASPECT_ID = "Id";
+    static final String ASPECT_AMOUNT = "Amount";
+
+    @Override
+    public ResourceLocation getUid() {
+        return UID;
+    }
+
+    @Override
+    public void appendServerData(CompoundTag tag, BlockAccessor accessor) {
+        BlockEntity blockEntity = accessor.getBlockEntity();
+        if (blockEntity instanceof BlockEntityNode) return;
+
+        if (blockEntity instanceof BlockEntityJar jar) {
+            writeStorage(tag, jar.getContents(accessor.getLevel().registryAccess()), jar.capacity());
+            tag.putString(AREA, "jar");
+            return;
+        }
+        if (blockEntity instanceof BlockEntityTubeBuffer buffer) {
+            writeStorage(tag, buffer.contents(), BlockEntityTubeBuffer.MAX_AMOUNT);
+            writeBufferState(tag, buffer);
+            return;
+        }
+        if (blockEntity instanceof BlockEntityTube tube) {
+            writeTube(tag, tube);
+            return;
+        }
+        if (blockEntity instanceof BlockEntityThaumatorium thaumatorium) {
+            writeStorage(tag, thaumatorium.essentia(), 0);
+            tag.putString(AREA, "thaumatorium");
+            tag.putInt(RECIPE_COUNT, thaumatorium.queue().size());
+            tag.putInt(RECIPE_CAPACITY, thaumatorium.maxRecipes());
+            return;
+        }
+        if (blockEntity instanceof BlockEntityCentrifuge centrifuge) {
+            tag.putBoolean(PRESENT, true);
+            writeSingleAspect(
+                    tag, centrifuge.getEssentiaType(Direction.UP), centrifuge.getEssentiaAmount(Direction.UP));
+            tag.putInt(CAPACITY, 1);
+            tag.putString(AREA, "centrifuge");
+            tag.putBoolean(ACTIVE, centrifuge.isSpinning());
+            return;
+        }
+        if (blockEntity instanceof IAspectContainer container) {
+            int capacity = blockEntity instanceof BlockEntityAlembic ? BlockEntityAlembic.CAPACITY : 0;
+            writeStorage(tag, container.getAspects(), capacity);
+            if (blockEntity instanceof BlockEntityAlembic alembic) {
+                tag.putString(AREA, "alembic");
+                tag.putBoolean(HAS_FILTER, true);
+                putAspect(tag, FILTER, alembic.aspectFilterKey());
+            }
+            if (blockEntity instanceof BlockEntityCrucible crucible) {
+                tag.putString(AREA, "crucible");
+                tag.putInt(CRUCIBLE_HEAT, crucible.getHeat());
+            }
+            return;
+        }
+        if (blockEntity instanceof IAspectQuery query) {
+            tag.putBoolean(PRESENT, true);
+            tag.putString(AREA, "filter");
+            writeFilter(tag, query.queryAspects());
+        }
+    }
+
+    private static void writeTube(CompoundTag tag, BlockEntityTube tube) {
+        tag.putBoolean(PRESENT, true);
+        writeSingleAspect(tag, tube.essentiaKey(), tube.essentiaAmountRaw());
+        tag.putInt(CAPACITY, 1);
+        String kind = tubeKind(tube);
+        tag.putString(TUBE_KIND, kind);
+        tag.putString(AREA, "normal".equals(kind) ? "tube" : kind);
+        tag.putString(FACING, tube.facing().getSerializedName());
+        tag.putInt(CLOSED_SIDES, closedMask(tube.openSides()));
+        tag.putInt(SUCTION, tube.suctionRaw());
+        putAspect(tag, SUCTION_ASPECT, tube.suctionKey());
+        if (tube instanceof BlockEntityTubeValve valve) {
+            tag.putBoolean(VALVE_OPEN, valve.allowFlow());
+        }
+        if (tube instanceof BlockEntityTubeFilter filter) {
+            writeFilter(tag, filter.queryAspects());
+        }
+    }
+
+    private static void writeBufferState(CompoundTag tag, BlockEntityTubeBuffer buffer) {
+        tag.putString(TUBE_KIND, "buffer");
+        tag.putString(AREA, "buffer");
+        tag.putString(FACING, buffer.facing().getSerializedName());
+        tag.putInt(CLOSED_SIDES, closedMask(buffer.openSides()));
+        byte[] choked = new byte[Direction.values().length];
+        for (Direction direction : Direction.values()) {
+            choked[direction.ordinal()] = (byte) buffer.chokedSide(direction);
+        }
+        tag.putByteArray(CHOKED_SIDES, choked);
+    }
+
+    private static String tubeKind(BlockEntityTube tube) {
+        if (tube instanceof BlockEntityTubeValve) return "valve";
+        if (tube instanceof BlockEntityTubeRestrict) return "restrict";
+        if (tube instanceof BlockEntityTubeFilter) return "filter";
+        if (tube instanceof BlockEntityTubeOneway) return "oneway";
+        return "normal";
+    }
+
+    private static int closedMask(boolean[] openSides) {
+        int mask = 0;
+        for (int i = 0; i < Math.min(openSides.length, Direction.values().length); i++) {
+            if (!openSides[i]) mask |= 1 << i;
+        }
+        return mask;
+    }
+
+    private static void writeStorage(CompoundTag tag, AspectList contents, int capacity) {
+        tag.putBoolean(PRESENT, true);
+        writeAspects(tag, contents);
+        if (capacity > 0) tag.putInt(CAPACITY, capacity);
+    }
+
+    private static void writeSingleAspect(CompoundTag tag, ResourceKey<IAspect> aspect, int amount) {
+        if (aspect == null || amount <= 0) return;
+        CompoundTag entry = new CompoundTag();
+        entry.putString(ASPECT_ID, aspect.location().toString());
+        entry.putInt(ASPECT_AMOUNT, amount);
+        ListTag contents = new ListTag();
+        contents.add(entry);
+        tag.put(CONTENTS, contents);
+    }
+
+    private static void writeSingleAspect(CompoundTag tag, net.minecraft.core.Holder<IAspect> aspect, int amount) {
+        if (aspect == null) return;
+        writeSingleAspect(tag, aspect.unwrapKey().orElse(null), amount);
+    }
+
+    private static void writeAspects(CompoundTag tag, AspectList aspects) {
+        ListTag contents = new ListTag();
+        for (AspectInstance entry : aspects.entries()) {
+            entry.aspect().unwrapKey().ifPresent(key -> {
+                CompoundTag encoded = new CompoundTag();
+                encoded.putString(ASPECT_ID, key.location().toString());
+                encoded.putInt(ASPECT_AMOUNT, entry.amount());
+                contents.add(encoded);
+            });
+        }
+        tag.put(CONTENTS, contents);
+    }
+
+    private static void writeFilter(CompoundTag tag, AspectList filter) {
+        tag.putBoolean(HAS_FILTER, true);
+        if (filter.isEmpty()) return;
+        filter.entries()
+                .getFirst()
+                .aspect()
+                .unwrapKey()
+                .ifPresent(key -> tag.putString(FILTER, key.location().toString()));
+    }
+
+    private static void putAspect(CompoundTag tag, String key, ResourceKey<IAspect> aspect) {
+        if (aspect != null) tag.putString(key, aspect.location().toString());
+    }
+}

--- a/src/main/java/com/leclowndu93150/thaumaturge/compat/jade/GolemComponentProvider.java
+++ b/src/main/java/com/leclowndu93150/thaumaturge/compat/jade/GolemComponentProvider.java
@@ -2,6 +2,7 @@ package com.leclowndu93150.thaumaturge.compat.jade;
 
 import com.leclowndu93150.thaumaturge.TCIds;
 import com.leclowndu93150.thaumaturge.content.golem.EntityThaumaturgeGolem;
+import com.leclowndu93150.thaumaturge.registry.TCGolemTraits;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
 import snownee.jade.api.EntityAccessor;
@@ -20,13 +21,24 @@ public enum GolemComponentProvider implements IEntityComponentProvider {
     }
 
     @Override
+    public boolean isRequired() {
+        return true;
+    }
+
+    @Override
     public void appendTooltip(ITooltip tooltip, EntityAccessor accessor, IPluginConfig config) {
-        if (!(accessor.getEntity() instanceof EntityThaumaturgeGolem golem)) {
+        if (!JadeConfig.shouldShow(config, JadeConfig.GOLEMS, accessor)) return;
+        if (!(accessor.getEntity() instanceof EntityThaumaturgeGolem golem)
+                || !golem.getProperties().hasTrait(TCGolemTraits.SMART.get())) {
             return;
         }
-        tooltip.add(Component.translatable(
-                "jade.thaumaturge.golem.rank",
-                golem.getProperties().getRank(),
-                accessor.getServerData().getInt("RankXp")));
+        int rank = golem.getProperties().getRank();
+        tooltip.add(Component.translatable("jade.thaumaturge.golem.rank", rank));
+        if (accessor.showDetails() && rank < EntityThaumaturgeGolem.MAX_RANK) {
+            tooltip.add(Component.translatable(
+                    "jade.thaumaturge.golem.xp",
+                    accessor.getServerData().getInt("RankXp"),
+                    accessor.getServerData().getInt("RankXpRequired")));
+        }
     }
 }

--- a/src/main/java/com/leclowndu93150/thaumaturge/compat/jade/GolemDataProvider.java
+++ b/src/main/java/com/leclowndu93150/thaumaturge/compat/jade/GolemDataProvider.java
@@ -2,6 +2,7 @@ package com.leclowndu93150.thaumaturge.compat.jade;
 
 import com.leclowndu93150.thaumaturge.TCIds;
 import com.leclowndu93150.thaumaturge.content.golem.EntityThaumaturgeGolem;
+import com.leclowndu93150.thaumaturge.registry.TCGolemTraits;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.resources.ResourceLocation;
 import snownee.jade.api.EntityAccessor;
@@ -18,9 +19,19 @@ public enum GolemDataProvider implements IServerDataProvider<EntityAccessor> {
     }
 
     @Override
+    public boolean shouldRequestData(EntityAccessor accessor) {
+        return accessor.showDetails()
+                && accessor.getEntity() instanceof EntityThaumaturgeGolem golem
+                && golem.getProperties().hasTrait(TCGolemTraits.SMART.get())
+                && golem.getProperties().getRank() < EntityThaumaturgeGolem.MAX_RANK;
+    }
+
+    @Override
     public void appendServerData(CompoundTag tag, EntityAccessor accessor) {
         if (accessor.getEntity() instanceof EntityThaumaturgeGolem golem) {
             tag.putInt("RankXp", golem.getRankXp());
+            int rank = golem.getProperties().getRank();
+            tag.putInt("RankXpRequired", (rank + 1) * (rank + 1) * EntityThaumaturgeGolem.XP_PER_RANK_UNIT);
         }
     }
 }

--- a/src/main/java/com/leclowndu93150/thaumaturge/compat/jade/JadeComponents.java
+++ b/src/main/java/com/leclowndu93150/thaumaturge/compat/jade/JadeComponents.java
@@ -3,23 +3,98 @@ package com.leclowndu93150.thaumaturge.compat.jade;
 import com.leclowndu93150.thaumaturge.api.aspect.AspectComponents;
 import com.leclowndu93150.thaumaturge.api.aspect.AspectInstance;
 import com.leclowndu93150.thaumaturge.api.aspect.AspectList;
+import com.leclowndu93150.thaumaturge.api.aspect.IAspect;
+import java.util.List;
+import net.minecraft.core.Direction;
+import net.minecraft.core.HolderLookup;
+import net.minecraft.core.RegistryAccess;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.ListTag;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MutableComponent;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.resources.ResourceLocation;
+import snownee.jade.api.ITooltip;
+import snownee.jade.api.ui.IElementHelper;
 
 final class JadeComponents {
+    private static final int MAX_ASPECT_LINE_WIDTH = 180;
+
     private JadeComponents() {}
 
-    static Component aspectLine(String key, AspectList aspects) {
+    static void addAspectLines(ITooltip tooltip, String key, AspectList aspects) {
+        List<AspectInstance> entries = aspects.entries();
+        int start = 0;
+        boolean firstLine = true;
+        while (start < entries.size()) {
+            int end = start + 1;
+            Component line = aspectLine(key, entries, start, end, firstLine);
+            while (end < entries.size()) {
+                Component candidate = aspectLine(key, entries, start, end + 1, firstLine);
+                if (IElementHelper.get().text(candidate).getSize().x > MAX_ASPECT_LINE_WIDTH) break;
+                line = candidate;
+                end++;
+            }
+            tooltip.add(line);
+            start = end;
+            firstLine = false;
+        }
+    }
+
+    private static Component aspectLine(
+            String key, List<AspectInstance> entries, int start, int end, boolean firstLine) {
         MutableComponent list = Component.empty();
-        boolean first = true;
-        for (AspectInstance entry : aspects.entries()) {
-            if (!first) {
+        for (int i = start; i < end; i++) {
+            if (i > start) {
                 list.append(Component.translatable("jade.thaumaturge.aspect_separator"));
             }
+            AspectInstance entry = entries.get(i);
             list.append(Component.translatable(
                     "jade.thaumaturge.aspect_amount", AspectComponents.name(entry.aspect()), entry.amount()));
+        }
+        return firstLine
+                ? Component.translatable(key, list)
+                : Component.literal("  ").append(list);
+    }
+
+    static AspectList decodeAspects(ListTag encoded, RegistryAccess registries) {
+        AspectList result = AspectList.EMPTY;
+        HolderLookup.RegistryLookup<IAspect> aspects = registries.lookupOrThrow(IAspect.REGISTRY_KEY);
+        for (int i = 0; i < encoded.size(); i++) {
+            CompoundTag entry = encoded.getCompound(i);
+            ResourceLocation id = ResourceLocation.tryParse(entry.getString(EssentiaDataProvider.ASPECT_ID));
+            if (id == null) continue;
+            var holder = aspects.get(ResourceKey.create(IAspect.REGISTRY_KEY, id));
+            if (holder.isPresent()) {
+                result = result.add(new AspectInstance(holder.get(), entry.getInt(EssentiaDataProvider.ASPECT_AMOUNT)));
+            }
+        }
+        return result;
+    }
+
+    static Component aspectName(String id, RegistryAccess registries) {
+        ResourceLocation location = ResourceLocation.tryParse(id);
+        if (location == null) return Component.translatable("tc.aspect.unknown");
+        return registries
+                .lookupOrThrow(IAspect.REGISTRY_KEY)
+                .get(ResourceKey.create(IAspect.REGISTRY_KEY, location))
+                .<Component>map(AspectComponents::name)
+                .orElseGet(() -> Component.translatable("tc.aspect.unknown"));
+    }
+
+    static Component direction(String name) {
+        return Component.translatable("jade.thaumaturge.direction." + name);
+    }
+
+    static Component directions(int mask) {
+        MutableComponent result = Component.empty();
+        boolean first = true;
+        for (Direction direction : Direction.values()) {
+            if ((mask & (1 << direction.ordinal())) == 0) continue;
+            if (!first) result.append(Component.literal(", "));
+            result.append(direction(direction.getSerializedName()));
             first = false;
         }
-        return Component.translatable(key, list);
+        return result;
     }
 }

--- a/src/main/java/com/leclowndu93150/thaumaturge/compat/jade/JadeConfig.java
+++ b/src/main/java/com/leclowndu93150/thaumaturge/compat/jade/JadeConfig.java
@@ -1,0 +1,95 @@
+package com.leclowndu93150.thaumaturge.compat.jade;
+
+import com.leclowndu93150.thaumaturge.TCIds;
+import com.leclowndu93150.thaumaturge.api.items.GogglesAccess;
+import java.util.List;
+import net.minecraft.network.chat.Component;
+import net.minecraft.resources.ResourceLocation;
+import snownee.jade.api.Accessor;
+import snownee.jade.api.IWailaClientRegistration;
+import snownee.jade.api.config.IPluginConfig;
+
+final class JadeConfig {
+    static final ResourceLocation CATEGORY = TCIds.rl("display");
+
+    static final ResourceLocation NODES = option("nodes");
+    static final ResourceLocation GOLEMS = option("golems");
+    static final ResourceLocation VIS_RELAYS = option("vis_relays");
+    static final ResourceLocation NODE_TRANSDUCERS = option("node_transducers");
+    static final ResourceLocation SMELTERS = option("smelters");
+    static final ResourceLocation JARS = option("jars");
+    static final ResourceLocation ALEMBICS = option("alembics");
+    static final ResourceLocation CRUCIBLES = option("crucibles");
+    static final ResourceLocation TUBES = option("tubes");
+    static final ResourceLocation VALVES = option("valves");
+    static final ResourceLocation RESTRICTED_TUBES = option("restricted_tubes");
+    static final ResourceLocation FILTER_TUBES = option("filter_tubes");
+    static final ResourceLocation ONE_WAY_TUBES = option("one_way_tubes");
+    static final ResourceLocation BUFFERS = option("buffers");
+    static final ResourceLocation THAUMATORIUMS = option("thaumatoriums");
+    static final ResourceLocation CENTRIFUGES = option("centrifuges");
+    static final ResourceLocation GOLEM_BUILDERS = option("golem_builders");
+    static final ResourceLocation VOID_SIPHONS = option("void_siphons");
+    static final ResourceLocation DECONSTRUCTION_TABLES = option("deconstruction_tables");
+    static final ResourceLocation SPAS = option("spas");
+    static final ResourceLocation EVERFULL_URNS = option("everfull_urns");
+    static final ResourceLocation INFERNAL_FURNACES = option("infernal_furnaces");
+    static final ResourceLocation FOCAL_MANIPULATORS = option("focal_manipulators");
+
+    private static final List<ResourceLocation> OPTIONS = List.of(
+            NODES,
+            GOLEMS,
+            VIS_RELAYS,
+            NODE_TRANSDUCERS,
+            SMELTERS,
+            JARS,
+            ALEMBICS,
+            CRUCIBLES,
+            TUBES,
+            VALVES,
+            RESTRICTED_TUBES,
+            FILTER_TUBES,
+            ONE_WAY_TUBES,
+            BUFFERS,
+            THAUMATORIUMS,
+            CENTRIFUGES,
+            GOLEM_BUILDERS,
+            VOID_SIPHONS,
+            DECONSTRUCTION_TABLES,
+            SPAS,
+            EVERFULL_URNS,
+            INFERNAL_FURNACES,
+            FOCAL_MANIPULATORS);
+
+    private JadeConfig() {}
+
+    static void register(IWailaClientRegistration registration) {
+        registration.addConfig(CATEGORY, true);
+        for (ResourceLocation option : OPTIONS) {
+            registration.addConfig(option, DisplayMode.GOGGLES);
+        }
+        registration.setConfigCategoryOverride(CATEGORY, Component.translatable("config.jade.thaumaturge"));
+    }
+
+    static boolean shouldShow(IPluginConfig config, ResourceLocation option, Accessor<?> accessor) {
+        return config.get(CATEGORY) && config.<DisplayMode>getEnum(option).shouldShow(accessor);
+    }
+
+    static ResourceLocation option(String name) {
+        return TCIds.rl("display." + name);
+    }
+
+    enum DisplayMode {
+        OFF,
+        ALWAYS,
+        GOGGLES;
+
+        boolean shouldShow(Accessor<?> accessor) {
+            return switch (this) {
+                case OFF -> false;
+                case ALWAYS -> true;
+                case GOGGLES -> GogglesAccess.wearsGoggles(accessor.getPlayer());
+            };
+        }
+    }
+}

--- a/src/main/java/com/leclowndu93150/thaumaturge/compat/jade/MachineComponentProvider.java
+++ b/src/main/java/com/leclowndu93150/thaumaturge/compat/jade/MachineComponentProvider.java
@@ -11,6 +11,7 @@ import snownee.jade.api.IBlockComponentProvider;
 import snownee.jade.api.ITooltip;
 import snownee.jade.api.JadeIds;
 import snownee.jade.api.config.IPluginConfig;
+import snownee.jade.api.theme.IThemeHelper;
 
 public enum MachineComponentProvider implements IBlockComponentProvider {
     INSTANCE;
@@ -69,9 +70,13 @@ public enum MachineComponentProvider implements IBlockComponentProvider {
         if (!show) return;
 
         if ("golem_builder".equals(area)) {
-            tooltip.replace(JadeIds.CORE_OBJECT_NAME, Component.translatable("block.thaumaturge.golem_builder"));
+            tooltip.replace(
+                    JadeIds.CORE_OBJECT_NAME,
+                    IThemeHelper.get().title(Component.translatable("block.thaumaturge.golem_builder")));
         } else if ("infernal_furnace".equals(area)) {
-            tooltip.replace(JadeIds.CORE_OBJECT_NAME, Component.translatable("block.thaumaturge.infernal_furnace"));
+            tooltip.replace(
+                    JadeIds.CORE_OBJECT_NAME,
+                    IThemeHelper.get().title(Component.translatable("block.thaumaturge.infernal_furnace")));
         }
 
         if (!"smelter".equals(area)) {

--- a/src/main/java/com/leclowndu93150/thaumaturge/compat/jade/MachineComponentProvider.java
+++ b/src/main/java/com/leclowndu93150/thaumaturge/compat/jade/MachineComponentProvider.java
@@ -3,13 +3,13 @@ package com.leclowndu93150.thaumaturge.compat.jade;
 import com.leclowndu93150.thaumaturge.TCIds;
 import com.leclowndu93150.thaumaturge.content.aura.node.BlockEntityNodeTransducer;
 import com.leclowndu93150.thaumaturge.content.aura.relay.BlockEntityVisRelay;
-import com.leclowndu93150.thaumaturge.content.essentia.smeltery.BlockEntitySmelter;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
 import snownee.jade.api.BlockAccessor;
 import snownee.jade.api.IBlockComponentProvider;
 import snownee.jade.api.ITooltip;
+import snownee.jade.api.JadeIds;
 import snownee.jade.api.config.IPluginConfig;
 
 public enum MachineComponentProvider implements IBlockComponentProvider {
@@ -23,10 +23,23 @@ public enum MachineComponentProvider implements IBlockComponentProvider {
     }
 
     @Override
+    public boolean isRequired() {
+        return true;
+    }
+
+    @Override
+    public int getDefaultPriority() {
+        return 1100;
+    }
+
+    @Override
     public void appendTooltip(ITooltip tooltip, BlockAccessor accessor, IPluginConfig config) {
         if (accessor.getBlockEntity() instanceof BlockEntityVisRelay relay) {
+            if (!JadeConfig.shouldShow(config, JadeConfig.VIS_RELAYS, accessor)) return;
             if (!relay.isLinked()) {
                 tooltip.add(Component.translatable("jade.thaumaturge.relay.unlinked"));
+            } else if (!accessor.showDetails()) {
+                tooltip.add(Component.translatable("jade.thaumaturge.relay.linked"));
             } else if (relay.depth() == 1) {
                 tooltip.add(Component.translatable("jade.thaumaturge.relay.linked_node"));
             } else {
@@ -35,25 +48,120 @@ public enum MachineComponentProvider implements IBlockComponentProvider {
             return;
         }
         if (accessor.getBlockEntity() instanceof BlockEntityNodeTransducer transducer) {
+            if (!JadeConfig.shouldShow(config, JadeConfig.NODE_TRANSDUCERS, accessor)) return;
             tooltip.add(Component.translatable("jade.thaumaturge.transducer.status." + transducer.getStatus()));
-            if (transducer.getStatus() != 0) {
+            if (transducer.getStatus() != 0 && accessor.showDetails()) {
                 tooltip.add(Component.translatable(
                         "jade.thaumaturge.transducer.charge",
                         transducer.getCount() * 100 / BlockEntityNodeTransducer.CHARGE_TARGET));
             }
             return;
         }
-        if (!(accessor.getBlockEntity() instanceof BlockEntitySmelter)) {
+        CompoundTag data = accessor.getServerData();
+        String area = data.getString(MachineDataProvider.AREA);
+        ResourceLocation option = machineOption(area);
+        if (option == null) return;
+        boolean show = JadeConfig.shouldShow(config, option, accessor);
+        if ("everfull_urn".equals(area)) {
+            if (!show) tooltip.remove(JadeIds.UNIVERSAL_FLUID_STORAGE);
             return;
         }
-        CompoundTag data = accessor.getServerData();
+        if (!show) return;
+
+        if ("golem_builder".equals(area)) {
+            tooltip.replace(JadeIds.CORE_OBJECT_NAME, Component.translatable("block.thaumaturge.golem_builder"));
+        } else if ("infernal_furnace".equals(area)) {
+            tooltip.replace(JadeIds.CORE_OBJECT_NAME, Component.translatable("block.thaumaturge.infernal_furnace"));
+        }
+
+        if (!"smelter".equals(area)) {
+            appendMachineState(tooltip, accessor, data, area, accessor.showDetails());
+            return;
+        }
         int progress = data.getInt("SmeltProgress");
         int burn = data.getInt("BurnRemaining");
+        tooltip.add(Component.translatable(
+                progress > 0 || burn > 0 ? "jade.thaumaturge.state.processing" : "jade.thaumaturge.state.idle"));
+        if (!accessor.showDetails()) return;
         if (progress > 0) {
             tooltip.add(Component.translatable("jade.thaumaturge.machine.progress", progress));
         }
         if (burn > 0) {
             tooltip.add(Component.translatable("jade.thaumaturge.machine.heat", burn));
         }
+    }
+
+    private static void appendMachineState(
+            ITooltip tooltip, BlockAccessor accessor, CompoundTag data, String area, boolean detailed) {
+        int progress = data.getInt("Progress");
+        int maximum = data.getInt("ProgressMax");
+        if ("golem_builder".equals(area)) {
+            tooltip.add(Component.translatable(
+                    maximum > 0 ? "jade.thaumaturge.state.processing" : "jade.thaumaturge.state.idle"));
+            if (detailed && maximum > 0) {
+                int percent = Math.min(100, Math.max(0, (maximum - progress) * 100 / maximum));
+                tooltip.add(Component.translatable("jade.thaumaturge.machine.progress", percent));
+            }
+            int output = data.getInt("OutputCount");
+            if (output > 0) {
+                tooltip.add(Component.translatable("jade.thaumaturge.machine.output", output));
+            }
+            return;
+        }
+        if (detailed && maximum > 0 && (!"deconstruction_table".equals(area) || data.getBoolean("HasInput"))) {
+            int percent = Math.min(100, Math.max(0, progress * 100 / maximum));
+            tooltip.add(Component.translatable("jade.thaumaturge.machine.progress", percent));
+        }
+
+        if ("void_siphon".equals(area)) {
+            tooltip.add(Component.translatable("jade.thaumaturge.machine.output", data.getInt("OutputCount")));
+        } else if ("deconstruction_table".equals(area)) {
+            if (!data.getBoolean("HasInput")) {
+                tooltip.add(Component.translatable("jade.thaumaturge.state.idle"));
+            }
+            String result = data.getString("ResultAspect");
+            if (!result.isEmpty()) {
+                tooltip.add(Component.translatable(
+                        "jade.thaumaturge.deconstruction.result",
+                        JadeComponents.aspectName(result, accessor.getLevel().registryAccess())));
+            }
+        } else if ("spa".equals(area)) {
+            if (detailed) {
+                tooltip.add(Component.translatable(
+                        "jade.thaumaturge.machine.fluid", data.getInt("Fluid"), data.getInt("FluidMax")));
+            }
+            tooltip.add(Component.translatable(
+                    data.getBoolean("Mix") ? "jade.thaumaturge.spa.mix" : "jade.thaumaturge.spa.water"));
+        } else if ("infernal_furnace".equals(area)) {
+            tooltip.add(Component.translatable("jade.thaumaturge.machine.stored_items", data.getInt("StoredItems")));
+        } else if ("focal_manipulator".equals(area)) {
+            if (detailed) {
+                tooltip.add(Component.translatable(
+                        "jade.thaumaturge.focal.vis", Math.round(data.getFloat("VisRemaining"))));
+            }
+            if (data.getBoolean("HasFocus")) {
+                String focusName = data.getString("FocusName");
+                tooltip.add(
+                        focusName.isEmpty()
+                                ? Component.translatable("jade.thaumaturge.focal.focus_inserted")
+                                : Component.translatable("jade.thaumaturge.focal.focus", focusName));
+            } else {
+                tooltip.add(Component.translatable("jade.thaumaturge.focal.no_focus"));
+            }
+        }
+    }
+
+    private static ResourceLocation machineOption(String area) {
+        return switch (area) {
+            case "smelter" -> JadeConfig.SMELTERS;
+            case "golem_builder" -> JadeConfig.GOLEM_BUILDERS;
+            case "void_siphon" -> JadeConfig.VOID_SIPHONS;
+            case "deconstruction_table" -> JadeConfig.DECONSTRUCTION_TABLES;
+            case "spa" -> JadeConfig.SPAS;
+            case "everfull_urn" -> JadeConfig.EVERFULL_URNS;
+            case "infernal_furnace" -> JadeConfig.INFERNAL_FURNACES;
+            case "focal_manipulator" -> JadeConfig.FOCAL_MANIPULATORS;
+            default -> null;
+        };
     }
 }

--- a/src/main/java/com/leclowndu93150/thaumaturge/compat/jade/MachineDataProvider.java
+++ b/src/main/java/com/leclowndu93150/thaumaturge/compat/jade/MachineDataProvider.java
@@ -1,9 +1,20 @@
 package com.leclowndu93150.thaumaturge.compat.jade;
 
 import com.leclowndu93150.thaumaturge.TCIds;
+import com.leclowndu93150.thaumaturge.content.casters.BlockEntityFocalManipulator;
+import com.leclowndu93150.thaumaturge.content.device.BlockEntityEverfullUrn;
+import com.leclowndu93150.thaumaturge.content.device.BlockEntityVoidSiphon;
 import com.leclowndu93150.thaumaturge.content.essentia.smeltery.BlockEntitySmelter;
+import com.leclowndu93150.thaumaturge.content.golem.press.BlockEntityGolemBuilder;
+import com.leclowndu93150.thaumaturge.content.infernalfurnace.BlockEntityInfernalFurnace;
+import com.leclowndu93150.thaumaturge.content.research.decon.BlockEntityDeconstructionTable;
+import com.leclowndu93150.thaumaturge.content.spa.BlockEntitySpa;
+import com.leclowndu93150.thaumaturge.registry.TCBlocks;
+import net.minecraft.core.BlockPos;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.state.BlockState;
 import snownee.jade.api.BlockAccessor;
 import snownee.jade.api.IServerDataProvider;
 
@@ -12,6 +23,7 @@ public enum MachineDataProvider implements IServerDataProvider<BlockAccessor> {
 
     private static final ResourceLocation UID = TCIds.rl("machine");
     static final int PERCENT = 100;
+    static final String AREA = "MachineArea";
 
     @Override
     public ResourceLocation getUid() {
@@ -20,9 +32,82 @@ public enum MachineDataProvider implements IServerDataProvider<BlockAccessor> {
 
     @Override
     public void appendServerData(CompoundTag tag, BlockAccessor accessor) {
-        if (accessor.getBlockEntity() instanceof BlockEntitySmelter smelter) {
+        BlockEntity machine = resolveMachine(accessor);
+        if (machine instanceof BlockEntitySmelter smelter) {
+            tag.putString(AREA, "smelter");
             tag.putInt("SmeltProgress", smelter.getCookProgressScaled(PERCENT));
             tag.putInt("BurnRemaining", smelter.getBurnTimeRemainingScaled(PERCENT));
+        } else if (machine instanceof BlockEntityGolemBuilder builder) {
+            tag.putString(AREA, "golem_builder");
+            tag.putInt("Progress", builder.cost());
+            tag.putInt("ProgressMax", builder.maxCost());
+            tag.putInt(
+                    "OutputCount",
+                    builder.output()
+                            .getStackInSlot(BlockEntityGolemBuilder.SLOT_OUTPUT)
+                            .getCount());
+        } else if (machine instanceof BlockEntityVoidSiphon siphon) {
+            tag.putString(AREA, "void_siphon");
+            tag.putInt("Progress", siphon.progress());
+            tag.putInt("ProgressMax", BlockEntityVoidSiphon.PROGRESS_REQUIRED);
+            tag.putInt("OutputCount", siphon.output().getStackInSlot(0).getCount());
+        } else if (machine instanceof BlockEntityDeconstructionTable table) {
+            tag.putString(AREA, "deconstruction_table");
+            tag.putBoolean(
+                    "HasInput",
+                    !table.items()
+                            .getStackInSlot(BlockEntityDeconstructionTable.SLOT_INPUT)
+                            .isEmpty());
+            tag.putInt("Progress", BlockEntityDeconstructionTable.BREAK_TIME_TICKS - table.breakTime());
+            tag.putInt("ProgressMax", BlockEntityDeconstructionTable.BREAK_TIME_TICKS);
+            if (table.resultAspect() != null)
+                tag.putString("ResultAspect", table.resultAspect().toString());
+        } else if (machine instanceof BlockEntitySpa spa) {
+            tag.putString(AREA, "spa");
+            tag.putInt("Fluid", spa.getTank().getFluidAmount());
+            tag.putInt("FluidMax", BlockEntitySpa.TANK_CAPACITY);
+            tag.putBoolean("Mix", spa.getMix());
+        } else if (machine instanceof BlockEntityEverfullUrn) {
+            tag.putString(AREA, "everfull_urn");
+        } else if (machine instanceof BlockEntityInfernalFurnace furnace) {
+            tag.putString(AREA, "infernal_furnace");
+            tag.putInt("Progress", furnace.furnaceCookTime);
+            tag.putInt("ProgressMax", furnace.furnaceMaxCookTime);
+            int stored = 0;
+            for (int slot = 0; slot < furnace.inventory().getSlots(); slot++) {
+                stored += furnace.inventory().getStackInSlot(slot).getCount();
+            }
+            tag.putInt("StoredItems", stored);
+        } else if (machine instanceof BlockEntityFocalManipulator manipulator) {
+            tag.putString(AREA, "focal_manipulator");
+            tag.putFloat("VisRemaining", manipulator.vis);
+            tag.putBoolean("HasFocus", !manipulator.focusStack().isEmpty());
+            tag.putString("FocusName", manipulator.focusName);
         }
+    }
+
+    private static BlockEntity resolveMachine(BlockAccessor accessor) {
+        BlockEntity direct = accessor.getBlockEntity();
+        if (direct != null) return direct;
+
+        BlockState state = accessor.getBlockState();
+        Class<? extends BlockEntity> controllerType;
+        if (state.is(TCBlocks.PLACEHOLDER_IRON_BARS)
+                || state.is(TCBlocks.PLACEHOLDER_ANVIL)
+                || state.is(TCBlocks.PLACEHOLDER_CAULDRON)
+                || state.is(TCBlocks.PLACEHOLDER_TABLE)) {
+            controllerType = BlockEntityGolemBuilder.class;
+        } else if (state.is(TCBlocks.NETHER_BRICKS_PLACEHOLDER) || state.is(TCBlocks.OBSIDIAN_PLACEHOLDER)) {
+            controllerType = BlockEntityInfernalFurnace.class;
+        } else {
+            return null;
+        }
+
+        BlockPos origin = accessor.getPosition();
+        for (BlockPos candidate : BlockPos.betweenClosed(origin.offset(-1, -1, -1), origin.offset(1, 1, 1))) {
+            BlockEntity nearby = accessor.getLevel().getBlockEntity(candidate);
+            if (controllerType.isInstance(nearby)) return nearby;
+        }
+        return null;
     }
 }

--- a/src/main/java/com/leclowndu93150/thaumaturge/compat/jade/NodeComponentProvider.java
+++ b/src/main/java/com/leclowndu93150/thaumaturge/compat/jade/NodeComponentProvider.java
@@ -4,6 +4,7 @@ import com.leclowndu93150.thaumaturge.TCIds;
 import com.leclowndu93150.thaumaturge.api.aspect.AspectList;
 import com.leclowndu93150.thaumaturge.api.items.GogglesAccess;
 import com.leclowndu93150.thaumaturge.api.nodes.NodeType;
+import com.leclowndu93150.thaumaturge.content.aura.node.BlockEntityJarNode;
 import com.leclowndu93150.thaumaturge.content.aura.node.BlockEntityNode;
 import com.leclowndu93150.thaumaturge.content.item.ThaumometerItem;
 import net.minecraft.ChatFormatting;
@@ -27,7 +28,13 @@ public enum NodeComponentProvider implements IBlockComponentProvider {
     }
 
     @Override
+    public boolean isRequired() {
+        return true;
+    }
+
+    @Override
     public void appendTooltip(ITooltip tooltip, BlockAccessor accessor, IPluginConfig config) {
+        if (!JadeConfig.shouldShow(config, JadeConfig.NODES, accessor)) return;
         if (!(accessor.getBlockEntity() instanceof BlockEntityNode node)) {
             return;
         }
@@ -37,7 +44,9 @@ public enum NodeComponentProvider implements IBlockComponentProvider {
                 && !(player.getOffhandItem().getItem() instanceof ThaumometerItem)) {
             return;
         }
-        if (node.getNodeType() != NodeType.NORMAL || node.getNodeModifier() != null) {
+        if (node instanceof BlockEntityJarNode
+                || node.getNodeType() != NodeType.NORMAL
+                || node.getNodeModifier() != null) {
             MutableComponent type = Component.translatable(
                     "jade.thaumaturge.node.type." + node.getNodeType().getSerializedName());
             if (node.getNodeModifier() != null) {
@@ -51,18 +60,19 @@ public enum NodeComponentProvider implements IBlockComponentProvider {
         }
         AspectList aspects = node.getAspects();
         if (!aspects.isEmpty()) {
-            tooltip.add(JadeComponents.aspectLine("jade.thaumaturge.node.aspects", aspects));
+            JadeComponents.addAspectLines(tooltip, "jade.thaumaturge.node.aspects", aspects);
         }
         if (node.isEnergized()) {
             tooltip.add(
                     Component.translatable("jade.thaumaturge.node.energized").withStyle(ChatFormatting.AQUA));
+            if (!accessor.showDetails()) return;
             tooltip.add(Component.translatable(
                     node.getNodeType() == NodeType.TAINTED
                             ? "jade.thaumaturge.node.feeds_flux"
                             : "jade.thaumaturge.node.feeds_aura"));
             AspectList original = node.getAspectsBaseOriginal();
             if (original != null && !original.isEmpty()) {
-                tooltip.add(JadeComponents.aspectLine("jade.thaumaturge.node.reverts_to", original));
+                JadeComponents.addAspectLines(tooltip, "jade.thaumaturge.node.reverts_to", original);
             }
         }
     }

--- a/src/main/java/com/leclowndu93150/thaumaturge/compat/jade/ThaumaturgeJadePlugin.java
+++ b/src/main/java/com/leclowndu93150/thaumaturge/compat/jade/ThaumaturgeJadePlugin.java
@@ -11,12 +11,14 @@ import snownee.jade.api.WailaPlugin;
 public final class ThaumaturgeJadePlugin implements IWailaPlugin {
     @Override
     public void register(IWailaCommonRegistration registration) {
+        registration.registerBlockDataProvider(EssentiaDataProvider.INSTANCE, Block.class);
         registration.registerBlockDataProvider(MachineDataProvider.INSTANCE, Block.class);
         registration.registerEntityDataProvider(GolemDataProvider.INSTANCE, EntityThaumaturgeGolem.class);
     }
 
     @Override
     public void registerClient(IWailaClientRegistration registration) {
+        JadeConfig.register(registration);
         registration.registerBlockComponent(NodeComponentProvider.INSTANCE, Block.class);
         registration.registerBlockComponent(EssentiaComponentProvider.INSTANCE, Block.class);
         registration.registerBlockComponent(MachineComponentProvider.INSTANCE, Block.class);

--- a/src/main/java/com/leclowndu93150/thaumaturge/data/lang/TCEnglishProvider.java
+++ b/src/main/java/com/leclowndu93150/thaumaturge/data/lang/TCEnglishProvider.java
@@ -1617,6 +1617,7 @@ public final class TCEnglishProvider extends LanguageProvider {
         add("jade.thaumaturge.essentia.fill", "%s: %s / %s");
         add("jade.thaumaturge.essentia.contents", "Essentia: %s");
         add("jade.thaumaturge.essentia.amount", "Essentia stored: %s / %s");
+        add("jade.thaumaturge.essentia.combined", "Essentia: %s %s/%s");
         add("jade.thaumaturge.essentia.filter", "Filtering: %s");
         add("jade.thaumaturge.essentia.unfiltered", "No filter set");
         add("jade.thaumaturge.tube.valve.open", "Valve: Open");

--- a/src/main/java/com/leclowndu93150/thaumaturge/data/lang/TCEnglishProvider.java
+++ b/src/main/java/com/leclowndu93150/thaumaturge/data/lang/TCEnglishProvider.java
@@ -1565,6 +1565,31 @@ public final class TCEnglishProvider extends LanguageProvider {
     }
 
     private void addJade() {
+        add("config.jade.thaumaturge", "Thaumcraft");
+        add("config.jade.plugin_thaumaturge.display", "Thaumcraft Overlay Information");
+        addJadeMode("nodes", "Aura Nodes");
+        addJadeMode("golems", "Golems");
+        addJadeMode("vis_relays", "Vis Relays");
+        addJadeMode("node_transducers", "Node Transducers");
+        addJadeMode("smelters", "Essentia Smelters");
+        addJadeMode("jars", "Essentia Jars and Tanks");
+        addJadeMode("alembics", "Alembics");
+        addJadeMode("crucibles", "Crucibles");
+        addJadeMode("tubes", "Essentia Tubes");
+        addJadeMode("valves", "Tube Valves");
+        addJadeMode("restricted_tubes", "Restricted Tubes");
+        addJadeMode("filter_tubes", "Filtered Tubes");
+        addJadeMode("one_way_tubes", "One-way Tubes");
+        addJadeMode("buffers", "Essentia Buffers");
+        addJadeMode("thaumatoriums", "Thaumatoriums");
+        addJadeMode("centrifuges", "Essentia Centrifuges");
+        addJadeMode("golem_builders", "Golem Builders");
+        addJadeMode("void_siphons", "Void Siphons");
+        addJadeMode("deconstruction_tables", "Deconstruction Tables");
+        addJadeMode("spas", "Arcane Spas");
+        addJadeMode("everfull_urns", "Everfull Urns");
+        addJadeMode("infernal_furnaces", "Infernal Furnaces");
+        addJadeMode("focal_manipulators", "Focal Manipulators");
         add("config.jade.plugin_thaumaturge.node", "Aura Node Info");
         add("config.jade.plugin_thaumaturge.essentia", "Essentia Contents");
         add("config.jade.plugin_thaumaturge.machine", "Machine Progress");
@@ -1586,11 +1611,47 @@ public final class TCEnglishProvider extends LanguageProvider {
         add("jade.thaumaturge.node.feeds_aura", "Condensing raw vis from the local aura");
         add("jade.thaumaturge.node.feeds_flux", "Devouring flux from the local aura");
         add("jade.thaumaturge.node.reverts_to", "Reverts to: %s");
-        add("jade.thaumaturge.essentia.empty", "Empty");
+        add("jade.thaumaturge.essentia.empty", "Essentia: Empty");
+        add("jade.thaumaturge.essentia.none", "Essentia: None");
+        add("jade.thaumaturge.essentia.empty_capacity", "Essentia: Empty (0 / %s)");
         add("jade.thaumaturge.essentia.fill", "%s: %s / %s");
         add("jade.thaumaturge.essentia.contents", "Essentia: %s");
+        add("jade.thaumaturge.essentia.amount", "Essentia stored: %s / %s");
         add("jade.thaumaturge.essentia.filter", "Filtering: %s");
         add("jade.thaumaturge.essentia.unfiltered", "No filter set");
+        add("jade.thaumaturge.tube.valve.open", "Valve: Open");
+        add("jade.thaumaturge.tube.valve.closed", "Valve: Closed");
+        add("jade.thaumaturge.tube.direction", "Flow direction: %s");
+        add("jade.thaumaturge.tube.restricted", "Restricted suction");
+        add("jade.thaumaturge.tube.suction", "Suction: %s (%s)");
+        add("jade.thaumaturge.tube.any_aspect", "Any essentia");
+        add("jade.thaumaturge.tube.closed_sides", "Closed sides: %s");
+        add("jade.thaumaturge.tube.choked", "Choke: %s (%s)");
+        add("jade.thaumaturge.tube.choke.reduced", "Reduced");
+        add("jade.thaumaturge.tube.choke.blocked", "Blocked");
+        add("jade.thaumaturge.crucible.state.cold", "Crucible: Cold");
+        add("jade.thaumaturge.crucible.state.heating", "Crucible: Heating");
+        add("jade.thaumaturge.crucible.state.boiling", "Crucible: Boiling");
+        add("jade.thaumaturge.direction.down", "Down");
+        add("jade.thaumaturge.direction.up", "Up");
+        add("jade.thaumaturge.direction.north", "North");
+        add("jade.thaumaturge.direction.south", "South");
+        add("jade.thaumaturge.direction.west", "West");
+        add("jade.thaumaturge.direction.east", "East");
+        add("jade.thaumaturge.thaumatorium.recipes", "Recipes: %s / %s");
+        add("jade.thaumaturge.centrifuge.state", "Centrifuge: %s");
+        add("jade.thaumaturge.state.idle", "Idle");
+        add("jade.thaumaturge.state.processing", "Processing");
+        add("jade.thaumaturge.machine.output", "Output items: %s");
+        add("jade.thaumaturge.machine.fluid", "Fluid: %s / %s mB");
+        add("jade.thaumaturge.machine.stored_items", "Stored items: %s");
+        add("jade.thaumaturge.deconstruction.result", "Pending aspect: %s");
+        add("jade.thaumaturge.spa.mix", "Mode: Mix bath salts");
+        add("jade.thaumaturge.spa.water", "Mode: Dispense fluid");
+        add("jade.thaumaturge.focal.vis", "Vis remaining: %s");
+        add("jade.thaumaturge.focal.focus", "Focus: %s");
+        add("jade.thaumaturge.focal.focus_inserted", "Focus inserted");
+        add("jade.thaumaturge.focal.no_focus", "No focus inserted");
         add("jade.thaumaturge.machine.progress", "Progress: %s%%");
         add("jade.thaumaturge.machine.heat", "Heat: %s%%");
         add("jade.thaumaturge.transducer.status.0", "No node below");
@@ -1598,8 +1659,17 @@ public final class TCEnglishProvider extends LanguageProvider {
         add("jade.thaumaturge.transducer.status.2", "Node energized");
         add("jade.thaumaturge.transducer.charge", "Charge: %s%%");
         add("jade.thaumaturge.relay.linked_node", "Linked to energized node");
+        add("jade.thaumaturge.relay.linked", "Linked");
         add("jade.thaumaturge.relay.linked_relay", "Linked through %s relays");
         add("jade.thaumaturge.relay.unlinked", "No energized node in range");
-        add("jade.thaumaturge.golem.rank", "Rank %s (%s XP)");
+        add("jade.thaumaturge.golem.rank", "Rank %s");
+        add("jade.thaumaturge.golem.xp", "Experience: %s / %s");
+    }
+
+    private void addJadeMode(String path, String label) {
+        String key = "config.jade.plugin_thaumaturge.display." + path;
+        add(key, label);
+        add(key + "_always", "Always");
+        add(key + "_goggles", "Goggles");
     }
 }


### PR DESCRIPTION
Adds useful information for essentia systems, machines, multiblocks, nodes, and golems. Retains the default goggles requirement while adding an option to display information without them.