### PR TITLE
[1.21.1] Fix gui blending after pausing

### DIFF
--- a/src/main/java/com/leclowndu93150/thaumaturge/client/hud/TCHudEvents.java
+++ b/src/main/java/com/leclowndu93150/thaumaturge/client/hud/TCHudEvents.java
@@ -2,6 +2,7 @@ package com.leclowndu93150.thaumaturge.client.hud;
 
 import com.leclowndu93150.thaumaturge.TCIds;
 import com.leclowndu93150.thaumaturge.client.casters.RadialFocusOverlay;
+import com.leclowndu93150.thaumaturge.client.render.GuiBlend;
 import java.util.List;
 import net.neoforged.api.distmarker.Dist;
 import net.neoforged.bus.api.SubscribeEvent;
@@ -18,10 +19,23 @@ public final class TCHudEvents {
         event.registerAbove(
                 VanillaGuiLayers.EXPERIENCE_LEVEL,
                 TCIds.rl("left_hud_stack"),
-                new LeftHudStack(List.of(CasterHudOverlay.dialGauge(), new AuraHudOverlay(), new SanityHudOverlay())));
-        event.registerAbove(VanillaGuiLayers.EXPERIENCE_LEVEL, TCIds.rl("knowledge_gain"), new KnowledgeGainOverlay());
-        event.registerAbove(VanillaGuiLayers.EXPERIENCE_LEVEL, TCIds.rl("caster_hud"), new CasterHudOverlay());
-        event.registerAbove(VanillaGuiLayers.EXPERIENCE_LEVEL, TCIds.rl("recharge_hud"), new RechargeHudOverlay());
-        event.registerAbove(VanillaGuiLayers.EXPERIENCE_LEVEL, TCIds.rl("radial_focus"), new RadialFocusOverlay());
+                GuiBlend.alphaBlendedLayer(new LeftHudStack(
+                        List.of(CasterHudOverlay.dialGauge(), new AuraHudOverlay(), new SanityHudOverlay()))));
+        event.registerAbove(
+                VanillaGuiLayers.EXPERIENCE_LEVEL,
+                TCIds.rl("knowledge_gain"),
+                GuiBlend.alphaBlendedLayer(new KnowledgeGainOverlay()));
+        event.registerAbove(
+                VanillaGuiLayers.EXPERIENCE_LEVEL,
+                TCIds.rl("caster_hud"),
+                GuiBlend.alphaBlendedLayer(new CasterHudOverlay()));
+        event.registerAbove(
+                VanillaGuiLayers.EXPERIENCE_LEVEL,
+                TCIds.rl("recharge_hud"),
+                GuiBlend.alphaBlendedLayer(new RechargeHudOverlay()));
+        event.registerAbove(
+                VanillaGuiLayers.EXPERIENCE_LEVEL,
+                TCIds.rl("radial_focus"),
+                GuiBlend.alphaBlendedLayer(new RadialFocusOverlay()));
     }
 }

--- a/src/main/java/com/leclowndu93150/thaumaturge/client/render/GuiBlend.java
+++ b/src/main/java/com/leclowndu93150/thaumaturge/client/render/GuiBlend.java
@@ -3,10 +3,29 @@ package com.leclowndu93150.thaumaturge.client.render;
 import com.mojang.blaze3d.platform.GlStateManager;
 import com.mojang.blaze3d.systems.RenderSystem;
 import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.client.gui.LayeredDraw;
 import net.minecraft.resources.ResourceLocation;
 
 public final class GuiBlend {
     private GuiBlend() {}
+
+    public static LayeredDraw.Layer alphaBlendedLayer(LayeredDraw.Layer layer) {
+        return (graphics, deltaTracker) -> withAlphaBlend(graphics, () -> layer.render(graphics, deltaTracker));
+    }
+
+    public static void withAlphaBlend(GuiGraphics graphics, Runnable draw) {
+        graphics.flush();
+        RenderSystem.enableBlend();
+        RenderSystem.defaultBlendFunc();
+        try {
+            draw.run();
+        } finally {
+            graphics.flush();
+            graphics.setColor(1.0F, 1.0F, 1.0F, 1.0F);
+            RenderSystem.defaultBlendFunc();
+            RenderSystem.disableBlend();
+        }
+    }
 
     public static void blitTinted(
             GuiGraphics graphics,

--- a/src/main/java/com/leclowndu93150/thaumaturge/client/screen/AbstractTCContainerScreen.java
+++ b/src/main/java/com/leclowndu93150/thaumaturge/client/screen/AbstractTCContainerScreen.java
@@ -1,5 +1,6 @@
 package com.leclowndu93150.thaumaturge.client.screen;
 
+import com.leclowndu93150.thaumaturge.client.render.GuiBlend;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen;
 import net.minecraft.network.chat.Component;
@@ -45,8 +46,10 @@ public abstract class AbstractTCContainerScreen<T extends AbstractContainerMenu>
 
     @Override
     protected void renderBg(GuiGraphics graphics, float partialTick, int mouseX, int mouseY) {
-        renderBackgroundTexture(graphics);
-        renderBackgroundOverlay(graphics, mouseX, mouseY, partialTick);
+        GuiBlend.withAlphaBlend(graphics, () -> {
+            renderBackgroundTexture(graphics);
+            renderBackgroundOverlay(graphics, mouseX, mouseY, partialTick);
+        });
     }
 
     protected void renderBackgroundTexture(GuiGraphics graphics) {

--- a/src/main/java/com/leclowndu93150/thaumaturge/client/screen/AbstractTCScreen.java
+++ b/src/main/java/com/leclowndu93150/thaumaturge/client/screen/AbstractTCScreen.java
@@ -1,5 +1,6 @@
 package com.leclowndu93150.thaumaturge.client.screen;
 
+import com.leclowndu93150.thaumaturge.client.render.GuiBlend;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.network.chat.Component;
@@ -34,7 +35,18 @@ public abstract class AbstractTCScreen extends Screen {
     public void renderBackground(GuiGraphics graphics, int mouseX, int mouseY, float partialTick) {
         super.renderBackground(graphics, mouseX, mouseY, partialTick);
         if (background != null) {
-            graphics.blit(background, 0, 0, 0.0F, 0.0F, width, height, backgroundTextureWidth, backgroundTextureHeight);
+            GuiBlend.withAlphaBlend(
+                    graphics,
+                    () -> graphics.blit(
+                            background,
+                            0,
+                            0,
+                            0.0F,
+                            0.0F,
+                            width,
+                            height,
+                            backgroundTextureWidth,
+                            backgroundTextureHeight));
         }
     }
 


### PR DESCRIPTION
Before:
<img width="313" height="auto" alt="image" src="https://github.com/user-attachments/assets/67ee2d4d-b150-42cb-bf96-5f8c4f34602f" />


After:
<img width="313" height="auto" alt="image" src="https://github.com/user-attachments/assets/00c7b1c8-7bcd-47b7-9e74-a821d3e007e3" />
