### PR TITLE
Fix pedestal server-client sync and item position when rendering

### DIFF
--- a/src/main/java/com/leclowndu93150/thaumaturge/client/render/blockentity/LegacyItemLift.java
+++ b/src/main/java/com/leclowndu93150/thaumaturge/client/render/blockentity/LegacyItemLift.java
@@ -25,6 +25,7 @@ public final class LegacyItemLift {
 
         PoseStack poseStack = new PoseStack();
         model.getTransforms().getTransform(context).apply(false, poseStack);
+        poseStack.translate(-0.5F, -0.5F, -0.5F);
         Matrix4f matrix = poseStack.last().pose();
 
         float[] bounds = {Float.POSITIVE_INFINITY, Float.NEGATIVE_INFINITY};

--- a/src/main/java/com/leclowndu93150/thaumaturge/content/infusion/BlockEntityPedestal.java
+++ b/src/main/java/com/leclowndu93150/thaumaturge/content/infusion/BlockEntityPedestal.java
@@ -7,6 +7,7 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.core.HolderLookup;
 import net.minecraft.nbt.CompoundTag;
+import net.minecraft.network.Connection;
 import net.minecraft.network.protocol.Packet;
 import net.minecraft.network.protocol.game.ClientGamePacketListener;
 import net.minecraft.network.protocol.game.ClientboundBlockEntityDataPacket;
@@ -73,6 +74,12 @@ public class BlockEntityPedestal extends BlockEntity {
     @Override
     public Packet<ClientGamePacketListener> getUpdatePacket() {
         return ClientboundBlockEntityDataPacket.create(this);
+    }
+
+    @Override
+    public void onDataPacket(
+            Connection connection, ClientboundBlockEntityDataPacket packet, HolderLookup.Provider registries) {
+        loadWithComponents(packet.getTag(), registries);
     }
 
     public @Nullable BlockPos findInstabilityMitigator() {


### PR DESCRIPTION
Fixes pedestal item rendering and desync when removing items.

Should fix #253 

<img width="551" height="789" alt="image" src="https://github.com/user-attachments/assets/4f14c591-b856-4cac-8465-f2fc9c0bbeb8" />
