### PR TITLE
[1.21.1] feat/fix: align pedestal items by rendered bounds

### DIFF
--- a/src/main/java/com/leclowndu93150/thaumaturge/client/render/blockentity/LegacyItemLift.java
+++ b/src/main/java/com/leclowndu93150/thaumaturge/client/render/blockentity/LegacyItemLift.java
@@ -1,9 +1,17 @@
 package com.leclowndu93150.thaumaturge.client.render.blockentity;
 
 import com.mojang.blaze3d.vertex.PoseStack;
+import com.mojang.blaze3d.vertex.VertexConsumer;
+import it.unimi.dsi.fastutil.longs.Long2FloatOpenHashMap;
+import java.util.IdentityHashMap;
 import java.util.List;
+import java.util.Map;
 import net.minecraft.client.Minecraft;
+import net.minecraft.client.renderer.LightTexture;
+import net.minecraft.client.renderer.MultiBufferSource;
+import net.minecraft.client.renderer.RenderType;
 import net.minecraft.client.renderer.block.model.BakedQuad;
+import net.minecraft.client.renderer.texture.OverlayTexture;
 import net.minecraft.client.resources.model.BakedModel;
 import net.minecraft.core.Direction;
 import net.minecraft.util.RandomSource;
@@ -15,14 +23,93 @@ import org.joml.Vector3f;
 public final class LegacyItemLift {
     public static final float LEGACY_CENTER_Y = 0.35F;
     private static final long QUAD_SEED = 42L;
+    private static final int MAX_BOTTOM_LIFT_CACHE_ENTRIES = 512;
+    private static final float MAX_REASONABLE_RENDER_BOUND = 64.0F;
+    private static final Long2FloatOpenHashMap BOTTOM_LIFT_CACHE = new Long2FloatOpenHashMap();
+
+    static {
+        BOTTOM_LIFT_CACHE.defaultReturnValue(Float.NaN);
+    }
 
     private LegacyItemLift() {}
 
     public static float centerLift(ItemStack stack, ItemDisplayContext context) {
         Minecraft minecraft = Minecraft.getInstance();
         BakedModel model = minecraft.getItemRenderer().getModel(stack, minecraft.level, null, 0);
-        RandomSource random = RandomSource.create(QUAD_SEED);
+        float[] bounds = bakedYBounds(model, context);
+        if (!usableBounds(bounds)) {
+            return LEGACY_CENTER_Y;
+        }
+        return LEGACY_CENTER_Y - (bounds[0] + bounds[1]) * 0.5F;
+    }
 
+    /**
+     * Returns the lift needed to put the lowest rendered vertex at Y=0.
+     *
+     * <p>The first lookup renders the item into a bounds-only vertex consumer. This follows Minecraft's actual item
+     * rendering path, so special/BEWLR renderers and third-party custom item renderers can be measured too. The result
+     * is cached by resolved model identity, item components, and display context, so subsequent frames are a cheap
+     * cache lookup.
+     *
+     * <p>If a custom renderer fails or emits unusable bounds, this falls back to the baked-model quad calculation. If
+     * neither path can provide valid geometry, zero lift is used as a safe final fallback.
+     */
+    public static float bottomLift(ItemStack stack, ItemDisplayContext context) {
+        if (stack.isEmpty()) {
+            return 0.0F;
+        }
+
+        Minecraft minecraft = Minecraft.getInstance();
+        BakedModel model = minecraft.getItemRenderer().getModel(stack, minecraft.level, null, 0);
+        long cacheKey = cacheKey(stack, context, model);
+        float cached = BOTTOM_LIFT_CACHE.get(cacheKey);
+        if (!Float.isNaN(cached)) {
+            return cached;
+        }
+
+        float lift = renderedBottomLift(minecraft, stack, context);
+        if (!Float.isFinite(lift)) {
+            float[] bounds = bakedYBounds(model, context);
+            lift = usableBounds(bounds) ? -bounds[0] : 0.0F;
+        }
+
+        cacheBottomLift(cacheKey, lift);
+        return lift;
+    }
+
+    /** Clears cached measurements after models are rebuilt during a resource reload. */
+    public static void clearBottomLiftCache() {
+        BOTTOM_LIFT_CACHE.clear();
+    }
+
+    private static float renderedBottomLift(Minecraft minecraft, ItemStack stack, ItemDisplayContext context) {
+        RenderBounds bounds = new RenderBounds();
+        Map<RenderType, VertexConsumer> consumers = new IdentityHashMap<>();
+        MultiBufferSource measuringBuffers =
+                renderType -> consumers.computeIfAbsent(renderType, ignored -> new BoundsVertexConsumer(bounds));
+        PoseStack poseStack = new PoseStack();
+
+        try {
+            minecraft
+                    .getItemRenderer()
+                    .renderStatic(
+                            stack,
+                            context,
+                            LightTexture.FULL_BRIGHT,
+                            OverlayTexture.NO_OVERLAY,
+                            poseStack,
+                            measuringBuffers,
+                            minecraft.level,
+                            0);
+        } catch (RuntimeException | LinkageError ignored) {
+            return Float.NaN;
+        }
+
+        return bounds.usable() ? -bounds.minY : Float.NaN;
+    }
+
+    private static float[] bakedYBounds(BakedModel model, ItemDisplayContext context) {
+        RandomSource random = RandomSource.create(QUAD_SEED);
         PoseStack poseStack = new PoseStack();
         model.getTransforms().getTransform(context).apply(false, poseStack);
         poseStack.translate(-0.5F, -0.5F, -0.5F);
@@ -33,10 +120,31 @@ public final class LegacyItemLift {
         for (Direction direction : Direction.values()) {
             accumulateY(model.getQuads(null, direction, random), matrix, bounds);
         }
-        if (bounds[0] > bounds[1]) {
-            return LEGACY_CENTER_Y;
+        return bounds;
+    }
+
+    private static boolean usableBounds(float[] bounds) {
+        return Float.isFinite(bounds[0])
+                && Float.isFinite(bounds[1])
+                && bounds[0] <= bounds[1]
+                && Math.abs(bounds[0]) <= MAX_REASONABLE_RENDER_BOUND
+                && Math.abs(bounds[1]) <= MAX_REASONABLE_RENDER_BOUND;
+    }
+
+    private static long cacheKey(ItemStack stack, ItemDisplayContext context, BakedModel model) {
+        int stackState = 31 * ItemStack.hashItemAndComponents(stack) + context.ordinal();
+        return ((long) System.identityHashCode(model) << 32) ^ Integer.toUnsignedLong(stackState);
+    }
+
+    private static void cacheBottomLift(long key, float lift) {
+        if (BOTTOM_LIFT_CACHE.size() >= MAX_BOTTOM_LIFT_CACHE_ENTRIES) {
+            var iterator = BOTTOM_LIFT_CACHE.keySet().iterator();
+            if (iterator.hasNext()) {
+                iterator.nextLong();
+                iterator.remove();
+            }
         }
-        return LEGACY_CENTER_Y - (bounds[0] + bounds[1]) * 0.5F;
+        BOTTOM_LIFT_CACHE.put(key, lift);
     }
 
     private static void accumulateY(List<BakedQuad> quads, Matrix4f matrix, float[] bounds) {
@@ -54,6 +162,69 @@ public final class LegacyItemLift {
                 bounds[0] = Math.min(bounds[0], corner.y);
                 bounds[1] = Math.max(bounds[1], corner.y);
             }
+        }
+    }
+
+    private static final class RenderBounds {
+        private float minY = Float.POSITIVE_INFINITY;
+        private float maxY = Float.NEGATIVE_INFINITY;
+        private boolean invalid;
+
+        private void include(float y) {
+            if (!Float.isFinite(y)) {
+                invalid = true;
+                return;
+            }
+            minY = Math.min(minY, y);
+            maxY = Math.max(maxY, y);
+        }
+
+        private boolean usable() {
+            return !invalid
+                    && Float.isFinite(minY)
+                    && Float.isFinite(maxY)
+                    && minY <= maxY
+                    && Math.abs(minY) <= MAX_REASONABLE_RENDER_BOUND
+                    && Math.abs(maxY) <= MAX_REASONABLE_RENDER_BOUND;
+        }
+    }
+
+    private static final class BoundsVertexConsumer implements VertexConsumer {
+        private final RenderBounds bounds;
+
+        private BoundsVertexConsumer(RenderBounds bounds) {
+            this.bounds = bounds;
+        }
+
+        @Override
+        public VertexConsumer addVertex(float x, float y, float z) {
+            bounds.include(y);
+            return this;
+        }
+
+        @Override
+        public VertexConsumer setColor(int red, int green, int blue, int alpha) {
+            return this;
+        }
+
+        @Override
+        public VertexConsumer setUv(float u, float v) {
+            return this;
+        }
+
+        @Override
+        public VertexConsumer setUv1(int u, int v) {
+            return this;
+        }
+
+        @Override
+        public VertexConsumer setUv2(int u, int v) {
+            return this;
+        }
+
+        @Override
+        public VertexConsumer setNormal(float normalX, float normalY, float normalZ) {
+            return this;
         }
     }
 }

--- a/src/main/java/com/leclowndu93150/thaumaturge/client/render/blockentity/PedestalRenderer.java
+++ b/src/main/java/com/leclowndu93150/thaumaturge/client/render/blockentity/PedestalRenderer.java
@@ -2,6 +2,7 @@ package com.leclowndu93150.thaumaturge.client.render.blockentity;
 
 import com.leclowndu93150.thaumaturge.client.render.ItemRenderHelper;
 import com.leclowndu93150.thaumaturge.content.infusion.BlockEntityPedestal;
+import com.leclowndu93150.thaumaturge.registry.TCBlocks;
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.math.Axis;
 import it.unimi.dsi.fastutil.HashCommon;
@@ -14,7 +15,8 @@ import net.minecraft.world.item.ItemStack;
 
 public final class PedestalRenderer<T extends BlockEntityPedestal> implements BlockEntityRenderer<T> {
     private static final float ITEM_SCALE = 1.25F;
-    private static final float ITEM_HEIGHT = 0.75F;
+    private static final float FULL_HEIGHT = 1.0F;
+    private static final float ANCIENT_AND_ELDRITCH_HEIGHT = 0.75F;
     private static final float SPIN_DEGREES_PER_TICK = 1.0F;
     private static final float VOXEL = 1.0F / 16.0F;
 
@@ -35,17 +37,24 @@ public final class PedestalRenderer<T extends BlockEntityPedestal> implements Bl
         if (stack.isEmpty()) {
             return;
         }
-        float groundLift = LegacyItemLift.centerLift(stack, ItemDisplayContext.GROUND) + VOXEL;
+        float groundLift = LegacyItemLift.bottomLift(stack, ItemDisplayContext.GROUND) + VOXEL;
         var viewEntity = Minecraft.getInstance().getCameraEntity();
         float ticks = viewEntity == null ? partialTick : viewEntity.tickCount + partialTick;
         float spin = ticks % 360.0F * SPIN_DEGREES_PER_TICK;
         poseStack.pushPose();
-        poseStack.translate(0.5F, ITEM_HEIGHT, 0.5F);
+        poseStack.translate(0.5F, pedestalHeight(pedestal), 0.5F);
         poseStack.scale(itemScale, itemScale, itemScale);
         poseStack.mulPose(Axis.YP.rotationDegrees(spin));
         poseStack.translate(0.0F, groundLift, 0.0F);
         int seed = HashCommon.long2int(pedestal.getBlockPos().asLong());
         ItemRenderHelper.render(stack, ItemDisplayContext.GROUND, poseStack, buffers, light, overlay, seed);
         poseStack.popPose();
+    }
+
+    private static float pedestalHeight(BlockEntityPedestal pedestal) {
+        var state = pedestal.getBlockState();
+        return state.is(TCBlocks.PEDESTAL_ANCIENT.get()) || state.is(TCBlocks.PEDESTAL_ELDRITCH.get())
+                ? ANCIENT_AND_ELDRITCH_HEIGHT
+                : FULL_HEIGHT;
     }
 }

--- a/src/main/java/com/leclowndu93150/thaumaturge/client/render/blockentity/TCBlockEntityRenderers.java
+++ b/src/main/java/com/leclowndu93150/thaumaturge/client/render/blockentity/TCBlockEntityRenderers.java
@@ -66,6 +66,11 @@ public final class TCBlockEntityRenderers {
     }
 
     @SubscribeEvent
+    public static void onModelsBaked(ModelEvent.BakingCompleted event) {
+        LegacyItemLift.clearBottomLiftCache();
+    }
+
+    @SubscribeEvent
     public static void onRegisterAdditionalModels(ModelEvent.RegisterAdditional event) {
         for (ModelResourceLocation modelId : BellowsRenderer.MODEL_IDS) {
             event.register(modelId);


### PR DESCRIPTION
measure and cache rendered item bounds so regular and custom-rendered items sit correctly on pedestals