### PR TITLE
[1.21.1] Add dynamic trees support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -189,6 +189,8 @@ dependencies {
     compileOnly "maven.modrinth:jade:${jade_version}"
     runtimeOnly "maven.modrinth:jade:${jade_version}"
 
+    compileOnly "maven.modrinth:vdjF5PL5:1.7.2"
+
     compileOnly "maven.modrinth:iris:${iris_version}"
     compileOnly "maven.modrinth:distanthorizons:${distant_horizons_version}"
 }

--- a/build.gradle
+++ b/build.gradle
@@ -130,6 +130,31 @@ neoForge {
 
 sourceSets.main.resources { srcDir 'src/generated/resources' }
 
+// Dynamic Trees discovers mod tree packs through the mod file itself. NeoForge's development
+// mod file points at the compiled classes directory rather than the separate resources output.
+// Mirror only the tree pack into that directory for development runs; the normal resources output
+// remains the sole copy packaged in release jars.
+// Removal note: delete this wiring, compat/dynamictrees, TCBiomeModifierSerializers and its
+// registration/data file, plus assets/dynamictrees and trees/thaumaturge. Native tree generation
+// needs no restoration: the modifier removes it only while Dynamic Trees is present and enabled.
+def syncDynamicTreesTreePack = tasks.register('syncDynamicTreesTreePack', Sync) {
+    from(sourceSets.main.resources)
+    include 'trees/**'
+    into(layout.buildDirectory.dir('classes/java/main'))
+}
+
+tasks.matching { it.name in ['runClient', 'runServer', 'runGameTestServer'] }.configureEach {
+    dependsOn syncDynamicTreesTreePack
+}
+
+def removeDynamicTreesTreePackForJar = tasks.register('removeDynamicTreesTreePackForJar', Delete) {
+    delete layout.buildDirectory.dir('classes/java/main/trees')
+}
+
+tasks.named('jar').configure {
+    dependsOn removeDynamicTreesTreePackForJar
+}
+
 tasks.register('generateData', Exec) {
     workingDir projectDir
     if (System.getProperty('os.name').toLowerCase().contains('windows')) {

--- a/src/main/java/com/leclowndu93150/thaumaturge/Thaumaturge.java
+++ b/src/main/java/com/leclowndu93150/thaumaturge/Thaumaturge.java
@@ -73,6 +73,7 @@ public final class Thaumaturge {
         TCMobEffects.register(modBus);
         TCAttributes.register(modBus);
         TCChunkGenerators.register(modBus);
+        TCBiomeModifierSerializers.register(modBus);
         TCPlacementModifiers.register(modBus);
         TCGolemTraits.register(modBus);
         TCFocusElements.register(modBus);

--- a/src/main/java/com/leclowndu93150/thaumaturge/compat/dynamictrees/DynamicTreesWorldgenBiomeModifier.java
+++ b/src/main/java/com/leclowndu93150/thaumaturge/compat/dynamictrees/DynamicTreesWorldgenBiomeModifier.java
@@ -1,10 +1,9 @@
 package com.leclowndu93150.thaumaturge.compat.dynamictrees;
 
+import com.dtteam.dynamictrees.config.DTConfigs;
 import com.leclowndu93150.thaumaturge.data.worldgen.feature.TCPlacedFeatures;
 import com.leclowndu93150.thaumaturge.registry.TCBiomeModifierSerializers;
 import com.mojang.serialization.MapCodec;
-import java.lang.reflect.Field;
-import java.lang.reflect.Method;
 import java.util.Set;
 import net.minecraft.core.Holder;
 import net.minecraft.resources.ResourceKey;
@@ -18,8 +17,8 @@ import net.neoforged.neoforge.common.world.ModifiableBiomeInfo;
 /**
  * Replaces only Thaumaturge's native tree placed features when Dynamic Trees has its own world generation enabled.
  *
- * <p>No Dynamic Trees classes are linked directly. If it is absent, changes its config API, or disables world
- * generation, this modifier does nothing and Thaumaturge's normal tree generation remains intact.</p>
+ * <p>Dynamic Trees is an optional compile-only dependency. If it is absent or has world generation disabled, this
+ * modifier does nothing and Thaumaturge's normal tree generation remains intact.</p>
  */
 public final class DynamicTreesWorldgenBiomeModifier implements BiomeModifier {
     private static final Set<ResourceKey<PlacedFeature>> NATIVE_TREE_FEATURES = Set.of(
@@ -44,21 +43,6 @@ public final class DynamicTreesWorldgenBiomeModifier implements BiomeModifier {
     }
 
     private static boolean isDynamicTreesWorldgenEnabled() {
-        if (!ModList.get().isLoaded("dynamictrees")) return false;
-
-        try {
-            Class<?> configs = Class.forName(
-                    "com.dtteam.dynamictrees.config.DTConfigs",
-                    false,
-                    DynamicTreesWorldgenBiomeModifier.class.getClassLoader());
-            Field server = configs.getField("SERVER");
-            Object serverConfig = server.get(null);
-            Field worldgen = configs.getField("worldGen");
-            Object setting = worldgen.get(serverConfig);
-            Method get = setting.getClass().getMethod("get");
-            return Boolean.TRUE.equals(get.invoke(setting));
-        } catch (ReflectiveOperationException | LinkageError | RuntimeException ignored) {
-            return false;
-        }
+        return ModList.get().isLoaded("dynamictrees") && DTConfigs.SERVER.worldGen.get();
     }
 }

--- a/src/main/java/com/leclowndu93150/thaumaturge/compat/dynamictrees/DynamicTreesWorldgenBiomeModifier.java
+++ b/src/main/java/com/leclowndu93150/thaumaturge/compat/dynamictrees/DynamicTreesWorldgenBiomeModifier.java
@@ -1,0 +1,64 @@
+package com.leclowndu93150.thaumaturge.compat.dynamictrees;
+
+import com.leclowndu93150.thaumaturge.data.worldgen.feature.TCPlacedFeatures;
+import com.leclowndu93150.thaumaturge.registry.TCBiomeModifierSerializers;
+import com.mojang.serialization.MapCodec;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.Set;
+import net.minecraft.core.Holder;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.world.level.biome.Biome;
+import net.minecraft.world.level.levelgen.GenerationStep;
+import net.minecraft.world.level.levelgen.placement.PlacedFeature;
+import net.neoforged.fml.ModList;
+import net.neoforged.neoforge.common.world.BiomeModifier;
+import net.neoforged.neoforge.common.world.ModifiableBiomeInfo;
+
+/**
+ * Replaces only Thaumaturge's native tree placed features when Dynamic Trees has its own world generation enabled.
+ *
+ * <p>No Dynamic Trees classes are linked directly. If it is absent, changes its config API, or disables world
+ * generation, this modifier does nothing and Thaumaturge's normal tree generation remains intact.</p>
+ */
+public final class DynamicTreesWorldgenBiomeModifier implements BiomeModifier {
+    private static final Set<ResourceKey<PlacedFeature>> NATIVE_TREE_FEATURES = Set.of(
+            TCPlacedFeatures.TREES_MAGIC_FOREST,
+            TCPlacedFeatures.GREATWOOD_NATURAL,
+            TCPlacedFeatures.GREATWOOD_NATURAL_RARE,
+            TCPlacedFeatures.SILVERWOOD_NATURAL);
+
+    @Override
+    public void modify(Holder<Biome> biome, Phase phase, ModifiableBiomeInfo.BiomeInfo.Builder builder) {
+        if (phase != Phase.REMOVE || !isDynamicTreesWorldgenEnabled()) return;
+
+        builder.getGenerationSettings()
+                .getFeatures(GenerationStep.Decoration.VEGETAL_DECORATION)
+                .removeIf(feature ->
+                        feature.unwrapKey().map(NATIVE_TREE_FEATURES::contains).orElse(false));
+    }
+
+    @Override
+    public MapCodec<? extends BiomeModifier> codec() {
+        return TCBiomeModifierSerializers.DYNAMIC_TREES_WORLDGEN.get();
+    }
+
+    private static boolean isDynamicTreesWorldgenEnabled() {
+        if (!ModList.get().isLoaded("dynamictrees")) return false;
+
+        try {
+            Class<?> configs = Class.forName(
+                    "com.dtteam.dynamictrees.config.DTConfigs",
+                    false,
+                    DynamicTreesWorldgenBiomeModifier.class.getClassLoader());
+            Field server = configs.getField("SERVER");
+            Object serverConfig = server.get(null);
+            Field worldgen = configs.getField("worldGen");
+            Object setting = worldgen.get(serverConfig);
+            Method get = setting.getClass().getMethod("get");
+            return Boolean.TRUE.equals(get.invoke(setting));
+        } catch (ReflectiveOperationException | LinkageError | RuntimeException ignored) {
+            return false;
+        }
+    }
+}

--- a/src/main/java/com/leclowndu93150/thaumaturge/data/lang/TCEnglishProvider.java
+++ b/src/main/java/com/leclowndu93150/thaumaturge/data/lang/TCEnglishProvider.java
@@ -18,6 +18,7 @@ public final class TCEnglishProvider extends LanguageProvider {
     @Override
     protected void addTranslations() {
         add("itemGroup.thaumaturge", "Thaumaturge");
+        add("treePack.thaumaturge.name", "Thaumaturge");
         addJade();
 
         aspect("aer", "Aer", "Air", "air");

--- a/src/main/java/com/leclowndu93150/thaumaturge/registry/TCBiomeModifierSerializers.java
+++ b/src/main/java/com/leclowndu93150/thaumaturge/registry/TCBiomeModifierSerializers.java
@@ -1,0 +1,24 @@
+package com.leclowndu93150.thaumaturge.registry;
+
+import com.leclowndu93150.thaumaturge.TCIds;
+import com.leclowndu93150.thaumaturge.compat.dynamictrees.DynamicTreesWorldgenBiomeModifier;
+import com.mojang.serialization.MapCodec;
+import java.util.function.Supplier;
+import net.neoforged.bus.api.IEventBus;
+import net.neoforged.neoforge.common.world.BiomeModifier;
+import net.neoforged.neoforge.registries.DeferredRegister;
+import net.neoforged.neoforge.registries.NeoForgeRegistries;
+
+public final class TCBiomeModifierSerializers {
+    private static final DeferredRegister<MapCodec<? extends BiomeModifier>> SERIALIZERS =
+            DeferredRegister.create(NeoForgeRegistries.Keys.BIOME_MODIFIER_SERIALIZERS, TCIds.MODID);
+
+    public static final Supplier<MapCodec<DynamicTreesWorldgenBiomeModifier>> DYNAMIC_TREES_WORLDGEN =
+            SERIALIZERS.register("dynamic_trees_worldgen", () -> MapCodec.unit(DynamicTreesWorldgenBiomeModifier::new));
+
+    private TCBiomeModifierSerializers() {}
+
+    public static void register(IEventBus eventBus) {
+        SERIALIZERS.register(eventBus);
+    }
+}

--- a/src/main/resources/assets/dynamictrees/blockstates/greatwood_branch.json
+++ b/src/main/resources/assets/dynamictrees/blockstates/greatwood_branch.json
@@ -1,0 +1,7 @@
+{
+  "variants": {
+    "": {
+      "model": "dynamictrees:block/greatwood_branch"
+    }
+  }
+}

--- a/src/main/resources/assets/dynamictrees/blockstates/greatwood_leaves.json
+++ b/src/main/resources/assets/dynamictrees/blockstates/greatwood_leaves.json
@@ -1,0 +1,7 @@
+{
+  "variants": {
+    "": {
+      "model": "thaumaturge:block/leaves_greatwood"
+    }
+  }
+}

--- a/src/main/resources/assets/dynamictrees/blockstates/greatwood_sapling.json
+++ b/src/main/resources/assets/dynamictrees/blockstates/greatwood_sapling.json
@@ -1,0 +1,7 @@
+{
+  "variants": {
+    "": {
+      "model": "dynamictrees:block/saplings/greatwood"
+    }
+  }
+}

--- a/src/main/resources/assets/dynamictrees/blockstates/silverwood_branch.json
+++ b/src/main/resources/assets/dynamictrees/blockstates/silverwood_branch.json
@@ -1,0 +1,7 @@
+{
+  "variants": {
+    "": {
+      "model": "dynamictrees:block/silverwood_branch"
+    }
+  }
+}

--- a/src/main/resources/assets/dynamictrees/blockstates/silverwood_leaves.json
+++ b/src/main/resources/assets/dynamictrees/blockstates/silverwood_leaves.json
@@ -1,0 +1,7 @@
+{
+  "variants": {
+    "": {
+      "model": "thaumaturge:block/leaves_silverwood"
+    }
+  }
+}

--- a/src/main/resources/assets/dynamictrees/blockstates/silverwood_sapling.json
+++ b/src/main/resources/assets/dynamictrees/blockstates/silverwood_sapling.json
@@ -1,0 +1,7 @@
+{
+  "variants": {
+    "": {
+      "model": "dynamictrees:block/saplings/silverwood"
+    }
+  }
+}

--- a/src/main/resources/assets/dynamictrees/blockstates/stripped_greatwood_branch.json
+++ b/src/main/resources/assets/dynamictrees/blockstates/stripped_greatwood_branch.json
@@ -1,0 +1,7 @@
+{
+  "variants": {
+    "": {
+      "model": "dynamictrees:block/stripped_greatwood_branch"
+    }
+  }
+}

--- a/src/main/resources/assets/dynamictrees/blockstates/stripped_silverwood_branch.json
+++ b/src/main/resources/assets/dynamictrees/blockstates/stripped_silverwood_branch.json
@@ -1,0 +1,7 @@
+{
+  "variants": {
+    "": {
+      "model": "dynamictrees:block/stripped_silverwood_branch"
+    }
+  }
+}

--- a/src/main/resources/assets/dynamictrees/models/block/greatwood_branch.json
+++ b/src/main/resources/assets/dynamictrees/models/block/greatwood_branch.json
@@ -1,0 +1,7 @@
+{
+  "loader": "dynamictrees:branch",
+  "textures": {
+    "bark": "thaumaturge:block/log_greatwood",
+    "rings": "thaumaturge:block/log_greatwood_top"
+  }
+}

--- a/src/main/resources/assets/dynamictrees/models/block/saplings/greatwood.json
+++ b/src/main/resources/assets/dynamictrees/models/block/saplings/greatwood.json
@@ -1,0 +1,8 @@
+{
+  "parent": "dynamictrees:block/smartmodel/sapling",
+  "render_type": "minecraft:cutout_mipped",
+  "textures": {
+    "leaves": "thaumaturge:block/leaves_greatwood",
+    "log": "thaumaturge:block/log_greatwood"
+  }
+}

--- a/src/main/resources/assets/dynamictrees/models/block/saplings/silverwood.json
+++ b/src/main/resources/assets/dynamictrees/models/block/saplings/silverwood.json
@@ -1,0 +1,8 @@
+{
+  "parent": "dynamictrees:block/smartmodel/sapling",
+  "render_type": "minecraft:cutout_mipped",
+  "textures": {
+    "leaves": "thaumaturge:block/leaves_silverwood",
+    "log": "thaumaturge:block/log_silverwood"
+  }
+}

--- a/src/main/resources/assets/dynamictrees/models/block/silverwood_branch.json
+++ b/src/main/resources/assets/dynamictrees/models/block/silverwood_branch.json
@@ -1,0 +1,7 @@
+{
+  "loader": "dynamictrees:branch",
+  "textures": {
+    "bark": "thaumaturge:block/log_silverwood",
+    "rings": "thaumaturge:block/log_silverwood_top"
+  }
+}

--- a/src/main/resources/assets/dynamictrees/models/block/stripped_greatwood_branch.json
+++ b/src/main/resources/assets/dynamictrees/models/block/stripped_greatwood_branch.json
@@ -1,0 +1,7 @@
+{
+  "loader": "dynamictrees:branch",
+  "textures": {
+    "bark": "thaumaturge:block/stripped_log_greatwood",
+    "rings": "thaumaturge:block/stripped_log_greatwood_top"
+  }
+}

--- a/src/main/resources/assets/dynamictrees/models/block/stripped_silverwood_branch.json
+++ b/src/main/resources/assets/dynamictrees/models/block/stripped_silverwood_branch.json
@@ -1,0 +1,7 @@
+{
+  "loader": "dynamictrees:branch",
+  "textures": {
+    "bark": "thaumaturge:block/stripped_log_silverwood",
+    "rings": "thaumaturge:block/stripped_log_silverwood_top"
+  }
+}

--- a/src/main/resources/assets/dynamictrees/models/item/greatwood_branch.json
+++ b/src/main/resources/assets/dynamictrees/models/item/greatwood_branch.json
@@ -1,0 +1,7 @@
+{
+  "parent": "dynamictrees:item/branch",
+  "textures": {
+    "bark": "thaumaturge:block/log_greatwood",
+    "rings": "thaumaturge:block/log_greatwood_top"
+  }
+}

--- a/src/main/resources/assets/dynamictrees/models/item/greatwood_seed.json
+++ b/src/main/resources/assets/dynamictrees/models/item/greatwood_seed.json
@@ -1,0 +1,6 @@
+{
+  "parent": "dynamictrees:item/standard_seed",
+  "textures": {
+    "layer0": "thaumaturge:block/sapling_greatwood"
+  }
+}

--- a/src/main/resources/assets/dynamictrees/models/item/silverwood_branch.json
+++ b/src/main/resources/assets/dynamictrees/models/item/silverwood_branch.json
@@ -1,0 +1,7 @@
+{
+  "parent": "dynamictrees:item/branch",
+  "textures": {
+    "bark": "thaumaturge:block/log_silverwood",
+    "rings": "thaumaturge:block/log_silverwood_top"
+  }
+}

--- a/src/main/resources/assets/dynamictrees/models/item/silverwood_seed.json
+++ b/src/main/resources/assets/dynamictrees/models/item/silverwood_seed.json
@@ -1,0 +1,6 @@
+{
+  "parent": "dynamictrees:item/standard_seed",
+  "textures": {
+    "layer0": "thaumaturge:block/sapling_silverwood"
+  }
+}

--- a/src/main/resources/assets/dynamictrees/models/item/stripped_greatwood_branch.json
+++ b/src/main/resources/assets/dynamictrees/models/item/stripped_greatwood_branch.json
@@ -1,0 +1,7 @@
+{
+  "parent": "dynamictrees:item/branch",
+  "textures": {
+    "bark": "thaumaturge:block/stripped_log_greatwood",
+    "rings": "thaumaturge:block/stripped_log_greatwood_top"
+  }
+}

--- a/src/main/resources/assets/dynamictrees/models/item/stripped_silverwood_branch.json
+++ b/src/main/resources/assets/dynamictrees/models/item/stripped_silverwood_branch.json
@@ -1,0 +1,7 @@
+{
+  "parent": "dynamictrees:item/branch",
+  "textures": {
+    "bark": "thaumaturge:block/stripped_log_silverwood",
+    "rings": "thaumaturge:block/stripped_log_silverwood_top"
+  }
+}

--- a/src/main/resources/data/thaumaturge/neoforge/biome_modifier/dynamic_trees_worldgen.json
+++ b/src/main/resources/data/thaumaturge/neoforge/biome_modifier/dynamic_trees_worldgen.json
@@ -1,0 +1,3 @@
+{
+  "type": "thaumaturge:dynamic_trees_worldgen"
+}

--- a/src/main/resources/trees/thaumaturge/families/greatwood.json
+++ b/src/main/resources/trees/thaumaturge/families/greatwood.json
@@ -1,0 +1,13 @@
+{
+  "common_leaves": "thaumaturge:greatwood",
+  "common_species": "thaumaturge:greatwood",
+  "primitive_log": "thaumaturge:log_greatwood",
+  "primitive_stripped_log": "thaumaturge:stripped_log_greatwood",
+  "max_branch_radius": 8,
+  "texture_overrides": {
+    "branch": "thaumaturge:block/log_greatwood",
+    "branch_top": "thaumaturge:block/log_greatwood_top",
+    "stripped_branch": "thaumaturge:block/stripped_log_greatwood",
+    "stripped_branch_top": "thaumaturge:block/stripped_log_greatwood_top"
+  }
+}

--- a/src/main/resources/trees/thaumaturge/families/silverwood.json
+++ b/src/main/resources/trees/thaumaturge/families/silverwood.json
@@ -1,0 +1,13 @@
+{
+  "common_leaves": "thaumaturge:silverwood",
+  "common_species": "thaumaturge:silverwood",
+  "primitive_log": "thaumaturge:log_silverwood",
+  "primitive_stripped_log": "thaumaturge:stripped_log_silverwood",
+  "max_branch_radius": 8,
+  "texture_overrides": {
+    "branch": "thaumaturge:block/log_silverwood",
+    "branch_top": "thaumaturge:block/log_silverwood_top",
+    "stripped_branch": "thaumaturge:block/stripped_log_silverwood",
+    "stripped_branch_top": "thaumaturge:block/stripped_log_silverwood_top"
+  }
+}

--- a/src/main/resources/trees/thaumaturge/leaves_properties/greatwood.json
+++ b/src/main/resources/trees/thaumaturge/leaves_properties/greatwood.json
@@ -1,0 +1,3 @@
+{
+  "primitive_leaves": "thaumaturge:leaves_greatwood"
+}

--- a/src/main/resources/trees/thaumaturge/leaves_properties/silverwood.json
+++ b/src/main/resources/trees/thaumaturge/leaves_properties/silverwood.json
@@ -1,0 +1,3 @@
+{
+  "primitive_leaves": "thaumaturge:leaves_silverwood"
+}

--- a/src/main/resources/trees/thaumaturge/species/greatwood.json
+++ b/src/main/resources/trees/thaumaturge/species/greatwood.json
@@ -1,0 +1,13 @@
+{
+  "family": "thaumaturge:greatwood",
+  "tapering": 0.3,
+  "signal_energy": 20.0,
+  "growth_rate": 0.7,
+  "leaves_properties": "thaumaturge:greatwood",
+  "preferred_climate": "temperate",
+  "climate_tolerance": 0.5,
+  "primitive_sapling": "thaumaturge:sapling_greatwood",
+  "lang_overrides": {
+    "seed": "Greatwood Seed"
+  }
+}

--- a/src/main/resources/trees/thaumaturge/species/silverwood.json
+++ b/src/main/resources/trees/thaumaturge/species/silverwood.json
@@ -1,0 +1,13 @@
+{
+  "family": "thaumaturge:silverwood",
+  "tapering": 0.3,
+  "signal_energy": 14.0,
+  "growth_rate": 0.65,
+  "leaves_properties": "thaumaturge:silverwood",
+  "preferred_climate": "temperate",
+  "climate_tolerance": 0.45,
+  "primitive_sapling": "thaumaturge:sapling_silverwood",
+  "lang_overrides": {
+    "seed": "Silverwood Seed"
+  }
+}

--- a/src/main/resources/trees/thaumaturge/world_gen/default.json
+++ b/src/main/resources/trees/thaumaturge/world_gen/default.json
@@ -1,0 +1,59 @@
+[
+  {
+    "select": "thaumaturge:magical_forest",
+    "apply": {
+      "species": {
+        "random": {
+          "oak": 31,
+          "thaumaturge:greatwood": 3,
+          "thaumaturge:silverwood": 2
+        }
+      },
+      "density": 0.35,
+      "chance": 1.0,
+      "forestness": 1.0
+    }
+  },
+  {
+    "select": {
+      "tag": "#thaumaturge:has_greatwood"
+    },
+    "apply": {
+      "species": {
+        "method": "SPLICE_BEFORE",
+        "random": {
+          "...": 24,
+          "thaumaturge:greatwood": 1
+        }
+      }
+    }
+  },
+  {
+    "select": {
+      "tag": "#thaumaturge:has_greatwood_rare"
+    },
+    "apply": {
+      "species": {
+        "method": "SPLICE_BEFORE",
+        "random": {
+          "...": 124,
+          "thaumaturge:greatwood": 1
+        }
+      }
+    }
+  },
+  {
+    "select": {
+      "tag": "#thaumaturge:has_silverwood"
+    },
+    "apply": {
+      "species": {
+        "method": "SPLICE_BEFORE",
+        "random": {
+          "...": 79,
+          "thaumaturge:silverwood": 1
+        }
+      }
+    }
+  }
+]

--- a/src/main/templates/META-INF/neoforge.mods.toml
+++ b/src/main/templates/META-INF/neoforge.mods.toml
@@ -89,6 +89,12 @@ type = "optional"
 versionRange = "[15.0.0,)"
 ordering = "AFTER"
 side = "BOTH"
+[[dependencies."${mod_id}"]]
+modId = "dynamictrees"
+type = "optional"
+versionRange = "[1.7.2,)"
+ordering = "AFTER"
+side = "BOTH"
 
 # Features are specific properties of the game environment, that you may want to declare you require. This example declares
 # that your mod requires GL version 3.2 or higher. Other features will be added. They are side aware so declaring this won't


### PR DESCRIPTION
relatively straight forward, zero mod dependencies and if they ever break support its easy to remove, just uses datapacks and a tiny guarded nf biome so our trees don't generate when dyntrees is installed